### PR TITLE
cloudflare: add firewall source metrics

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -77,9 +77,9 @@ type zoneResp struct {
 			ColoCode string `json:"coloCode"`
 		} `json:"dimensions"`
 		Count uint64 `json:"count"`
-		Sum struct {
+		Sum   struct {
 			EdgeResponseBytes uint64 `json:"edgeResponseBytes"`
-			Visits uint64 `json:"visits"`
+			Visits            uint64 `json:"visits"`
 		} `json:"sum"`
 		Avg struct {
 			sampleInterval uint64 `json:"sampleInterval"`
@@ -89,9 +89,10 @@ type zoneResp struct {
 	FirewallEventsAdaptiveGroups []struct {
 		Count      uint64 `json:"count"`
 		Dimensions struct {
-			Action                   string `json:"action"`
-			ClientCountryName string `json:"clientCountryName"`
-			ClientRequestHTTPHost    string `json:"clientRequestHTTPHost"`
+			Action                string `json:"action"`
+			Source                string `json:"source"`
+			ClientCountryName     string `json:"clientCountryName"`
+			ClientRequestHTTPHost string `json:"clientRequestHTTPHost"`
 		} `json:"dimensions"`
 	} `json:"firewallEventsAdaptiveGroups"`
 

--- a/prometheus.go
+++ b/prometheus.go
@@ -153,7 +153,7 @@ var (
 	zoneFirewallEventsCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "cloudflare_zone_firewall_events_count",
 		Help: "Count of Firewall events",
-	}, []string{"zone", "action", "host", "country"})
+	}, []string{"zone", "action", "source", "host", "country"})
 )
 
 func fetchZoneColocationAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
@@ -251,10 +251,11 @@ func addFirewallGroups(z *zoneResp, name string) {
 	for _, g := range z.FirewallEventsAdaptiveGroups {
 		zoneFirewallEventsCount.With(
 			prometheus.Labels{
-				"zone":     name,
-				"action":   g.Dimensions.Action,
-				"host":     g.Dimensions.ClientRequestHTTPHost,
-				"country":  g.Dimensions.ClientCountryName,
+				"zone":    name,
+				"action":  g.Dimensions.Action,
+				"source":  g.Dimensions.Source,
+				"host":    g.Dimensions.ClientRequestHTTPHost,
+				"country": g.Dimensions.ClientCountryName,
 			}).Add(float64(g.Count))
 	}
 }


### PR DESCRIPTION
By adding the [source](https://developers.cloudflare.com/logs/log-fields#firewall-events) of a Firewall Event, we get visibility into which security product was responsible for affecting a request (e.g ratelimit).