### PR TITLE
Add metrics for workers.

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -19,10 +19,31 @@ type cloudflareResponse struct {
 	} `json:"viewer"`
 }
 
+type cloudflareResponseAccts struct {
+	Viewer struct {
+		Accounts []accountResp `json:"accounts"`
+	} `json:"viewer"`
+}
+
 type cloudflareResponseColo struct {
 	Viewer struct {
 		Zones []zoneRespColo `json:"zones"`
 	} `json:"viewer"`
+}
+
+type accountResp struct {
+	WorkersInvocationsAdaptive []struct {
+		Dimensions struct {
+			ScriptName string `json:"scriptName"`
+			Status     string `json:"status"`
+		}
+
+		Sum struct {
+			Requests uint64  `json:"requests"`
+			Errors   uint64  `json:"errors"`
+			Duration float64 `json:"duration"`
+		} `json:"sum"`
+	} `json:"workersInvocationsAdaptive"`
 }
 
 type zoneRespColo struct {
@@ -156,7 +177,26 @@ func fetchZones() []cloudflare.Zone {
 	}
 
 	return z
+}
 
+func fetchAccounts() []cloudflare.Account {
+	var api *cloudflare.API
+	var err error
+	if len(cfgCfAPIToken) > 0 {
+		api, err = cloudflare.NewWithAPIToken(cfgCfAPIToken)
+	} else {
+		api, err = cloudflare.New(cfgCfAPIKey, cfgCfAPIEmail)
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	a, _, err := api.Accounts(cloudflare.PaginationOptions{PerPage: 100})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return a
 }
 
 func fetchZoneTotals(zoneIDs []string) (*cloudflareResponse, error) {
@@ -329,6 +369,55 @@ func fetchColoTotals(zoneIDs []string) (*cloudflareResponseColo, error) {
 	ctx := context.Background()
 	graphqlClient := graphql.NewClient(cfGraphQLEndpoint)
 	var resp cloudflareResponseColo
+	if err := graphqlClient.Run(ctx, request, &resp); err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func fetchWorkerTotals(accountID string) (*cloudflareResponseAccts, error) {
+	now := time.Now().Add(-180 * time.Second).UTC()
+	s := 60 * time.Second
+	now = now.Truncate(s)
+	now1mAgo := now.Add(-60 * time.Second)
+
+	request := graphql.NewRequest(`
+	query ($accountID: String!, $mintime: Time!, $maxtime: Time!, $limit: Int!) {
+		viewer {
+			accounts(filter: {accountTag: $accountID} ) {
+				workersInvocationsAdaptive(limit: $limit, filter: { datetime_geq: $mintime, datetime_lt: $maxtime}) {
+					dimensions {
+						scriptName
+						status
+						datetime
+					}
+
+					sum {
+						requests
+						errors
+						duration
+					}
+				}
+			}
+		}
+	}
+`)
+	if len(cfgCfAPIToken) > 0 {
+		request.Header.Set("Authorization", "Bearer "+cfgCfAPIToken)
+	} else {
+		request.Header.Set("X-AUTH-EMAIL", cfgCfAPIEmail)
+		request.Header.Set("X-AUTH-KEY", cfgCfAPIKey)
+	}
+	request.Var("limit", 9999)
+	request.Var("maxtime", now)
+	request.Var("mintime", now1mAgo)
+	request.Var("accountID", accountID)
+
+	ctx := context.Background()
+	graphqlClient := graphql.NewClient(cfGraphQLEndpoint)
+	var resp cloudflareResponseAccts
 	if err := graphqlClient.Run(ctx, request, &resp); err != nil {
 		log.Error(err)
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -61,8 +61,13 @@ func filterZones(all []cloudflare.Zone, target []string) []cloudflare.Zone {
 func fetchMetrics() {
 	var wg sync.WaitGroup
 	zones := fetchZones()
+	accounts := fetchAccounts()
 
 	filteredZones := filterZones(zones, getTargetZones())
+
+	for _, a := range accounts {
+		go fetchWorkerAnalytics(a, &wg)
+	}
 
 	// Make requests in groups of 10 to avoid rate limit
 	// 10 is the maximum amount of zones you can request at once

--- a/prometheus.go
+++ b/prometheus.go
@@ -173,7 +173,36 @@ var (
 		Help: "Number of Heath check events per region per origin",
 	}, []string{"zone", "health_status", "origin_ip", "region"},
 	)
+
+	workerRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "cloudflare_worker_requests_count",
+		Help: "Number of requests sent to worker by script name",
+	}, []string{"script_name"},
+	)
+
+	workerErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "cloudflare_worker_errors_count",
+		Help: "Number of errors by script name",
+	}, []string{"script_name"},
+	)
 )
+
+func fetchWorkerAnalytics(account cloudflare.Account, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
+	r, err := fetchWorkerTotals(account.ID)
+	if err != nil {
+		return
+	}
+
+	for _, a := range r.Viewer.Accounts {
+		for _, w := range a.WorkersInvocationsAdaptive {
+			workerRequests.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName}).Add(float64(w.Sum.Requests))
+			workerErrors.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName}).Add(float64(w.Sum.Errors))
+		}
+	}
+}
 
 func fetchZoneColocationAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 	wg.Add(1)


### PR DESCRIPTION
This actions issue #17 .

The functionality is there and will introspect the accounts the CF TOKEN has access to and then get worker metrics from there.

Not sure if this is the wanted behaviour as the token will need extra permissions (which i will update the readme with once things are looking good :) ).

Should I add a `CF_ACCOUNTS` env var to limit accounts to check? If the var does not exists it will not get any worker metrics, so its backward compatible?