### PR TITLE
Fix identation for serviceMonitor.labels

### DIFF
--- a/charts/cloudflare-exporter/Chart.yaml
+++ b/charts/cloudflare-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cloudflare-exporter
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.0.6
 home: https://github.com/lablabs/cloudflare-exporter
 description: A Helm chart for cloudflare exporter

--- a/charts/cloudflare-exporter/templates/servicemonitor.yaml
+++ b/charts/cloudflare-exporter/templates/servicemonitor.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "cloudflare-exporter.labels" . | nindent 4 }}
   {{- if .Values.serviceMonitor.labels }}
-    {{ toYaml .Values.serviceMonitor.labels | indent 4 }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
   {{- end }}
   name: {{ template "cloudflare-exporter.fullname" . }}
 {{- if .Values.serviceMonitor.namespace }}


### PR DESCRIPTION
This is a real simple fix for the identation of `.Values.serviceMonitor.labels`.

Previously, with the following `values.yaml` it produces an error in identation:
```yaml
serviceMonitor:
  # Whether to create service account
  enabled: true
  labels:
    foo: bar
```

```bash
# Source: cloudflare-exporter/templates/servicemonitor.yaml

apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  labels:
    helm.sh/chart: cloudflare-exporter-0.1.1
    app.kubernetes.io/name: cloudflare-exporter
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "0.0.6"
    app.kubernetes.io/managed-by: Helm
        foo: bar
  name: RELEASE-NAME-cloudflare-exporter
...
 not allowed in this context
helm.go:81: [debug] error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context
YAML parse error on cloudflare-exporter/templates/servicemonitor.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
        /home/circleci/helm.sh/helm/pkg/releaseutil/manifest_sorter.go:146
helm.sh/helm/v3/pkg/releaseutil.SortManifests
        /home/circleci/helm.sh/helm/pkg/releaseutil/manifest_sorter.go:106
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
        /home/circleci/helm.sh/helm/pkg/action/action.go:165
helm.sh/helm/v3/pkg/action.(*Install).Run
        /home/circleci/helm.sh/helm/pkg/action/install.go:240
main.runInstall
        /home/circleci/helm.sh/helm/cmd/helm/install.go:242
main.newTemplateCmd.func2
        /home/circleci/helm.sh/helm/cmd/helm/template.go:73
github.com/spf13/cobra.(*Command).execute
        /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:850
github.com/spf13/cobra.(*Command).ExecuteC
        /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958
github.com/spf13/cobra.(*Command).Execute
        /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
main.main
        /home/circleci/helm.sh/helm/cmd/helm/helm.go:80
runtime.main
        /usr/local/go/src/runtime/proc.go:204
runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:1374

```