### PR TITLE
Add configurable scrape delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Another configuration options are command line flags, same as environmental vari
   -cf_zones="": cloudflare zones to export, comma delimited list
   -listen=":8080": listen on addr:port ( default :8080), omit addr to listen on all interfaces
   -metrics_path="/metrics": path for metrics, default /metrics
+  -scrape_delay=300: scrape delay in seconds, defaults to 300
 ```
 
 ### Changes in in version 0.0.5+

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -161,7 +161,7 @@ func fetchZones() []cloudflare.Zone {
 }
 
 func fetchZoneTotals(zoneIDs []string) (*cloudflareResponse, error) {
-	now := time.Now().Add(-180 * time.Second).UTC()
+	now := time.Now().Add(-time.Duration(cfgScrapeDelay) * time.Second).UTC()
 	s := 60 * time.Second
 	now = now.Truncate(s)
 	now1mAgo := now.Add(-60 * time.Second)
@@ -227,7 +227,7 @@ query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!) {
 			firewallEventsAdaptiveGroups(limit: $limit, filter: { datetime_geq: $mintime, datetime_lt: $maxtime }) {
 				count
 				dimensions {
-				  action	
+				  action
 				  source
 				  clientRequestHTTPHost
 				  clientCountryName
@@ -285,7 +285,7 @@ query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!) {
 }
 
 func fetchColoTotals(zoneIDs []string) (*cloudflareResponseColo, error) {
-	now := time.Now().Add(-180 * time.Second).UTC()
+	now := time.Now().Add(-time.Duration(cfgScrapeDelay) * time.Second).UTC()
 	s := 60 * time.Second
 	now = now.Truncate(s)
 	now1mAgo := now.Add(-60 * time.Second)

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ var (
 	cfgCfAPIToken  = ""
 	cfgMetricsPath = "/metrics"
 	cfgZones       = ""
+	cfgScrapeDelay = 300
 )
 
 func getTargetZones() []string {
@@ -89,6 +90,7 @@ func main() {
 	flag.StringVar(&cfgCfAPIEmail, "cf_api_email", cfgCfAPIEmail, "cloudflare api email, works with api_key flag")
 	flag.StringVar(&cfgCfAPIToken, "cf_api_token", cfgCfAPIToken, "cloudflare api token (preferred)")
 	flag.StringVar(&cfgZones, "cf_zones", cfgZones, "cloudflare zones to export, comma delimited list")
+	flag.IntVar(&cfgScrapeDelay, "scrape_delay", cfgScrapeDelay , "scrape delay in seconds, defaults to 180")
 	flag.Parse()
 	if !(len(cfgCfAPIToken) > 0 || (len(cfgCfAPIEmail) > 0 && len(cfgCfAPIKey) > 0)) {
 		log.Fatal("Please provide CF_API_KEY+CF_API_EMAIL or CF_API_TOKEN")

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func main() {
 	flag.StringVar(&cfgCfAPIEmail, "cf_api_email", cfgCfAPIEmail, "cloudflare api email, works with api_key flag")
 	flag.StringVar(&cfgCfAPIToken, "cf_api_token", cfgCfAPIToken, "cloudflare api token (preferred)")
 	flag.StringVar(&cfgZones, "cf_zones", cfgZones, "cloudflare zones to export, comma delimited list")
-	flag.IntVar(&cfgScrapeDelay, "scrape_delay", cfgScrapeDelay , "scrape delay in seconds, defaults to 180")
+	flag.IntVar(&cfgScrapeDelay, "scrape_delay", cfgScrapeDelay , "scrape delay in seconds, defaults to 300")
 	flag.Parse()
 	if !(len(cfgCfAPIToken) > 0 || (len(cfgCfAPIEmail) > 0 && len(cfgCfAPIKey) > 0)) {
 		log.Fatal("Please provide CF_API_KEY+CF_API_EMAIL or CF_API_TOKEN")


### PR DESCRIPTION
Adds option to configure `scrape_delay` interval. Defaults to 5 minutes.

This PR addresses the issue described in https://github.com/lablabs/cloudflare-exporter/issues/18