### PR TITLE
fix: change gha version to SHA

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -19,7 +19,7 @@ jobs:
             compress: 'false'
             dest: 'dist'
       - name: Copy build-artifacts
-        uses: skx/github-action-publish-binaries@master
+        uses: skx/github-action-publish-binaries@c881a3f8ffb80b684f367660178d38ceabc065c2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
[CI-601](https://toptal-core.atlassian.net/browse/CI-601)
Using master as as version of 3rd party GitHub action is a potential security risk.
We are changing from:
`uses:  skx/github-action-publish-binaries@master`
to:
`uses:  skx/github-action-publish-binaries@<SHA-key>`
What I did is just went to the repository, and got the latest SHA of the master.

**3rd party GHA repositories changed within this PR:**

- [https://github.com/toptal/cloudflare-exporter](url)

**How to test**

- Green check on this PR is enough
