### PR TITLE
health check add fqdn

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -133,6 +133,7 @@ type zoneResp struct {
 			OriginIP      string `json:"originIP"`
 			FailureReason string `json:"failureReason"`
 			Region        string `json:"region"`
+			Fqdn          string `json:"fqdn"`
 		} `json:"dimensions"`
 	} `json:"healthCheckEventsAdaptiveGroups"`
 
@@ -255,6 +256,7 @@ query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!) {
 					healthStatus
 					originIP
 					region
+					fqdn
 				}
 			}
 		}

--- a/prometheus.go
+++ b/prometheus.go
@@ -171,7 +171,7 @@ var (
 	zoneHealthCheckEventsOriginCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "cloudflare_zone_health_check_events_origin_count",
 		Help: "Number of Heath check events per region per origin",
-	}, []string{"zone", "health_status", "origin_ip", "region"},
+	}, []string{"zone", "health_status", "origin_ip", "region", "fqdn"},
 	)
 )
 
@@ -291,6 +291,7 @@ func addHealthCheckGroups(z *zoneResp, name string) {
 				"health_status": g.Dimensions.HealthStatus,
 				"origin_ip":     g.Dimensions.OriginIP,
 				"region":        g.Dimensions.Region,
+				"fqdn":          g.Dimensions.Fqdn,
 			}).Add(float64(g.Count))
 	}
 }


### PR DESCRIPTION
In some cases, when one ip addr is serving multiple vhosts ( s3/loadbalancer/reverse proxy/vip/etc..), origin ip is not enough to distinguish between different health checks. Fqdn should solve this problem. 