### PR TITLE
Add `CpuTime` and `Duration` quantiles to worker metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The original method of zone filtering by using env variables `ZONE_<name>` is no
 ## List of available metrics
 
 ```
+# HELP cloudflare_worker_cpu_time CPU time quantiles by script name
+# HELP cloudflare_worker_duration Duration quantiles by script name (GB*s)
 # HELP cloudflare_worker_errors_count Number of errors by script name
 # HELP cloudflare_worker_requests_count Number of requests sent to worker by script name
 # HELP cloudflare_zone_bandwidth_cached Cached bandwidth per zone in bytes

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/cloudflare/cloudflare-go"
 	"github.com/machinebox/graphql"
 	log "github.com/sirupsen/logrus"
 )
@@ -43,6 +43,17 @@ type accountResp struct {
 			Errors   uint64  `json:"errors"`
 			Duration float64 `json:"duration"`
 		} `json:"sum"`
+
+		Quantiles struct {
+			CpuTimeP50   float32 `json:"cpuTimeP50"`
+			CpuTimeP75   float32 `json:"cpuTimeP75"`
+			CpuTimeP99   float32 `json:"cpuTimeP99"`
+			CpuTimeP999  float32 `json:"cpuTimeP999"`
+			DurationP50  float32 `json:"durationP50"`
+			DurationP75  float32 `json:"durationP75"`
+			DurationP99  float32 `json:"durationP99"`
+			DurationP999 float32 `json:"durationP999"`
+		} `json:"quantiles"`
 	} `json:"workersInvocationsAdaptive"`
 }
 
@@ -401,6 +412,17 @@ func fetchWorkerTotals(accountID string) (*cloudflareResponseAccts, error) {
 						requests
 						errors
 						duration
+					}
+
+					quantiles {
+						cpuTimeP50
+						cpuTimeP75
+						cpuTimeP99
+						cpuTimeP999
+						durationP50
+						durationP75
+						durationP99
+						durationP999
 					}
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/cloudflare/cloudflare-go"
 	"github.com/namsral/flag"
 	"github.com/nelkinda/health-go"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -22,6 +22,7 @@ var (
 	cfgMetricsPath = "/metrics"
 	cfgZones       = ""
 	cfgScrapeDelay = 300
+	cfgFreeTier    = false
 )
 
 func getTargetZones() []string {
@@ -30,7 +31,7 @@ func getTargetZones() []string {
 	if len(cfgZones) > 0 {
 		zoneIDs = strings.Split(cfgZones, ",")
 	} else {
-		//depricated
+		// deprecated
 		for _, e := range os.Environ() {
 			if strings.HasPrefix(e, "ZONE_") {
 				split := strings.SplitN(e, "=", 2)
@@ -64,7 +65,6 @@ func fetchMetrics() {
 	var wg sync.WaitGroup
 	zones := fetchZones()
 	accounts := fetchAccounts()
-
 	filteredZones := filterZones(zones, getTargetZones())
 
 	for _, a := range accounts {
@@ -96,7 +96,8 @@ func main() {
 	flag.StringVar(&cfgCfAPIEmail, "cf_api_email", cfgCfAPIEmail, "cloudflare api email, works with api_key flag")
 	flag.StringVar(&cfgCfAPIToken, "cf_api_token", cfgCfAPIToken, "cloudflare api token (preferred)")
 	flag.StringVar(&cfgZones, "cf_zones", cfgZones, "cloudflare zones to export, comma delimited list")
-	flag.IntVar(&cfgScrapeDelay, "scrape_delay", cfgScrapeDelay , "scrape delay in seconds, defaults to 300")
+	flag.IntVar(&cfgScrapeDelay, "scrape_delay", cfgScrapeDelay, "scrape delay in seconds, defaults to 300")
+	flag.BoolVar(&cfgFreeTier, "free_tier", cfgFreeTier, "scrape only metrics included in free plan")
 	flag.Parse()
 	if !(len(cfgCfAPIToken) > 0 || (len(cfgCfAPIEmail) > 0 && len(cfgCfAPIKey) > 0)) {
 		log.Fatal("Please provide CF_API_KEY+CF_API_EMAIL or CF_API_TOKEN")


### PR DESCRIPTION
This PR extends the worker metrics by providing quantiles for used CPU time and duration for invocations:

![2021-10-13-135301_659x275_scrot](https://user-images.githubusercontent.com/479022/137129595-706cc0df-2e95-4061-a3ce-14cd5b631873.png)


I also took the liberty of resolving the errors for trying to fetch non-free metrics on free zones: 
```
zone 'xxx' does not have access to the path
```

This is done by adding a `free_tier` variable/flag which disables non-free metric polling. It's backwards compatible, if not explicitly set the default behaviour is to scrape everything. Currently, this leaves only worker metrics. In the future, one can imagine allowing to configure scraping of `httpRequestGroups1h` (instead of `1m`) for free tier metrics but didn't want to scope creep too much. :)