### PR TITLE
Add total requests per colocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Note: `ZONE_<name>` configuration is not supported as flag.
 # HELP cloudflare_zone_bandwidth_total Total bandwidth per zone in bytes
 # HELP cloudflare_zone_colocation_edge_response_bytes Edge response bytes per colocation
 # HELP cloudflare_zone_colocation_visits Total visits per colocation
+# HELP cloudflare_zone_colocation_requests_total Total requests per colocation
 # HELP cloudflare_zone_pageviews_total Pageviews per zone
 # HELP cloudflare_zone_requests_cached Number of cached requests for zone
 # HELP cloudflare_zone_requests_content_type Number of request for zone per content type

--- a/prometheus.go
+++ b/prometheus.go
@@ -242,7 +242,7 @@ func fetchZoneColocationAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 		for _, c := range cg {
 			zoneColocationVisits.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Sum.Visits))
 			zoneColocationEdgeResponseBytes.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Sum.EdgeResponseBytes))
-      zoneColocationRequestsTotal.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Count))
+      			zoneColocationRequestsTotal.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Count))
 		}
 	}
 }

--- a/prometheus.go
+++ b/prometheus.go
@@ -138,6 +138,12 @@ var (
 	}, []string{"zone", "colocation"},
 	)
 
+	zoneColocationRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "cloudflare_zone_colocation_requests_total",
+		Help: "Total requests per colocation",
+	}, []string{"zone", "colocation"},
+	)
+
 	zoneFirewallEventsCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "cloudflare_zone_firewall_events_count",
 		Help: "Count of Firewall events",
@@ -230,6 +236,7 @@ func fetchZoneColocationAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 		for _, c := range cg {
 			zoneColocationVisits.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode}).Add(float64(c.Sum.Visits))
 			zoneColocationEdgeResponseBytes.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode}).Add(float64(c.Sum.EdgeResponseBytes))
+			zoneColocationRequestsTotal.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode}).Add(float64(c.Count))
 		}
 	}
 }


### PR DESCRIPTION
Currently, only the counter of total visits per colocation is exported, this PR introduces the counter of total requests per colocation, as instructed here: [Zone Analytics Colos Endpoint to GraphQL Analytics](https://developers.cloudflare.com/analytics/graphql-api/migration-guides/zone-analytics-colos/#:~:text=The%20following%20is,bandwidth%3A%20.sum.edgeResponseBytes%7D%27).