### PR TITLE
Filter non Free plan zones from graphql metrics

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -598,3 +598,12 @@ func extractZoneIDs(zones []cloudflare.Zone) []string {
 
 	return IDs
 }
+
+func filterNonFreePlanZones(zones []cloudflare.Zone) (filteredZones []cloudflare.Zone) {
+	for _, z := range zones {
+		if z.Plan.ZonePlanCommon.ID != "0feeeeeeeeeeeeeeeeeeeeeeeeeeeeee" {
+			filteredZones = append(filteredZones, z)
+		}
+	}
+	return
+}

--- a/prometheus.go
+++ b/prometheus.go
@@ -222,7 +222,11 @@ func fetchZoneColocationAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 	if cfgFreeTier {
 		return
 	}
-	zoneIDs := extractZoneIDs(zones)
+
+	zoneIDs := extractZoneIDs(filterNonFreePlanZones(zones))
+	if len(zoneIDs) == 0 {
+		return
+	}
 
 	r, err := fetchColoTotals(zoneIDs)
 	if err != nil {
@@ -249,7 +253,10 @@ func fetchZoneAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 		return
 	}
 
-	zoneIDs := extractZoneIDs(zones)
+	zoneIDs := extractZoneIDs(filterNonFreePlanZones(zones))
+	if len(zoneIDs) == 0 {
+		return
+	}
 
 	r, err := fetchZoneTotals(zoneIDs)
 	if err != nil {
@@ -382,7 +389,10 @@ func fetchLoadBalancerAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 		return
 	}
 
-	zoneIDs := extractZoneIDs(zones)
+	zoneIDs := extractZoneIDs(filterNonFreePlanZones(zones))
+	if len(zoneIDs) == 0 {
+		return
+	}
 
 	l, err := fetchLoadBalancerTotals(zoneIDs)
 	if err != nil {


### PR DESCRIPTION
This should prevent access errors, when an account has a mix of Free and Premium Zones. As well as "empty zone filters not allowed" error when the array is empty.