### PR TITLE
Fix panic in "Add total requests per colocation"

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -141,7 +141,7 @@ var (
 	zoneColocationRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "cloudflare_zone_colocation_requests_total",
 		Help: "Total requests per colocation",
-	}, []string{"zone", "colocation"},
+	}, []string{"zone", "colocation", "host"},
 	)
 
 	zoneFirewallEventsCount = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -246,7 +246,7 @@ func fetchZoneColocationAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 		for _, c := range cg {
 			zoneColocationVisits.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Sum.Visits))
 			zoneColocationEdgeResponseBytes.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Sum.EdgeResponseBytes))
-      			zoneColocationRequestsTotal.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Count))
+      		zoneColocationRequestsTotal.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Count))
 		}
 	}
 }


### PR DESCRIPTION
`panic: inconsistent label cardinality: expected 2 label values but got 3 in prometheus.Labels{"colocation":"AMS", "host":"abc.abc.com", "zone":"abc.com"}`

Something should be done to the latest release ASAP.