### PR TITLE
dockerfile: alpine:3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY go.sum go.sum
 RUN go get -d -v
 RUN CGO_ENABLED=0 GOOS=linux go build -o cloudflare_exporter .
 
-FROM alpine:3.12
+FROM alpine:3.16
 
 RUN apk update && apk add ca-certificates
 


### PR DESCRIPTION
Update the alpine base image from `3.12` to `3.16`.

Per https://endoflife.date/alpine or https://alpinelinux.org/releases/ , support for `3.12` ended on `2022-05-01`.
Support for `3.16` will continue to `2024-05-23`.
