### PR TITLE
dependabot for /Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "Shopify/infrasec"


### PR DESCRIPTION
Add a [Dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) configuration file to monitor `/Dockerfile`.

This means Dependabot will automatically open PRs like #72 , to keep the alpine base image up to date.