### PR TITLE
Feat: Allow adding annoations to the Deployment

### DIFF
--- a/charts/cloudflare-exporter/Chart.yaml
+++ b/charts/cloudflare-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cloudflare-exporter
-version: 0.1.8
+version: 0.1.9
 appVersion: 0.0.9
 home: https://github.com/lablabs/cloudflare-exporter
 description: A Helm chart for cloudflare exporter

--- a/charts/cloudflare-exporter/templates/deployment.yaml
+++ b/charts/cloudflare-exporter/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "cloudflare-exporter.fullname" . }}
   labels:
     {{- include "cloudflare-exporter.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/cloudflare-exporter/values.yaml
+++ b/charts/cloudflare-exporter/values.yaml
@@ -17,6 +17,8 @@ fullnameOverride: ""
 
 podAnnotations: {}
 
+deploymentAnnotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
If using something such as [Reloader](https://github.com/stakater/Reloader) to watch/monitor for secret rotation, you may need to add annoations to the deployment.
