### PR TITLE
Add Cloudflare Logpush metrics for account and zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Note: `ZONE_<name>` configuration is not supported as flag.
 # HELP cloudflare_zone_uniques_total Uniques per zone
 # HELP cloudflare_zone_pool_health_status Reports the health of a pool, 1 for healthy, 0 for unhealthy
 # HELP cloudflare_zone_pool_requests_total Requests per pool
+# HELP cloudflare_logpush_failed_jobs_account_count Number of failed logpush jobs on the account level
+# HELP cloudflare_logpush_failed_jobs_zone_count Number of failed logpush jobs on the zone level
 ```
 
 ## Helm chart repository

--- a/main.go
+++ b/main.go
@@ -108,6 +108,7 @@ func fetchMetrics() {
 
 	for _, a := range accounts {
 		go fetchWorkerAnalytics(a, &wg)
+		go fetchLogpushAnalyticsForAccount(a, &wg)
 	}
 
 	// Make requests in groups of cfgBatchSize to avoid rate limit
@@ -124,6 +125,7 @@ func fetchMetrics() {
 		go fetchZoneAnalytics(targetZones, &wg)
 		go fetchZoneColocationAnalytics(targetZones, &wg)
 		go fetchLoadBalancerAnalytics(targetZones, &wg)
+		go fetchLogpushAnalyticsForZone(targetZones, &wg)
 	}
 
 	wg.Wait()

--- a/prometheus.go
+++ b/prometheus.go
@@ -47,6 +47,8 @@ const (
 	workerDurationMetricName                     MetricName = "cloudflare_worker_duration"
 	poolHealthStatusMetricName                   MetricName = "cloudflare_zone_pool_health_status"
 	poolRequestsTotalMetricName                  MetricName = "cloudflare_zone_pool_requests_total"
+	logpushFailedJobsAccountMetricName           MetricName = "cloudflare_logpush_failed_jobs_account_count"
+	logpushFailedJobsZoneMetricName              MetricName = "cloudflare_logpush_failed_jobs_zone_count"
 )
 
 type MetricsSet map[MetricName]struct{}
@@ -243,6 +245,21 @@ var (
 	},
 		[]string{"zone", "load_balancer_name", "pool_name", "origin_name"},
 	)
+
+	// TODO: Update this to counter vec and use counts from the query to add
+	logpushFailedJobsAccount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: logpushFailedJobsAccountMetricName.String(),
+		Help: "Number of failed logpush jobs on the account level",
+	},
+		[]string{"destination", "job_id", "final"},
+	)
+
+	logpushFailedJobsZone = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: logpushFailedJobsZoneMetricName.String(),
+		Help: "Number of failed logpush jobs on the zone level",
+	},
+		[]string{"destination", "job_id", "final"},
+	)
 )
 
 func buildAllMetricsSet() MetricsSet {
@@ -277,6 +294,8 @@ func buildAllMetricsSet() MetricsSet {
 	allMetricsSet.Add(workerDurationMetricName)
 	allMetricsSet.Add(poolHealthStatusMetricName)
 	allMetricsSet.Add(poolRequestsTotalMetricName)
+	allMetricsSet.Add(logpushFailedJobsAccountMetricName)
+	allMetricsSet.Add(logpushFailedJobsZoneMetricName)
 	return allMetricsSet
 }
 
@@ -383,6 +402,12 @@ func mustRegisterMetrics(deniedMetrics MetricsSet) {
 	if !deniedMetrics.Has(poolRequestsTotalMetricName) {
 		prometheus.MustRegister(poolRequestsTotal)
 	}
+	if !deniedMetrics.Has(logpushFailedJobsAccountMetricName) {
+		prometheus.MustRegister(logpushFailedJobsAccount)
+	}
+	if !deniedMetrics.Has(logpushFailedJobsZoneMetricName) {
+		prometheus.MustRegister(logpushFailedJobsZone)
+	}
 }
 
 func fetchWorkerAnalytics(account cloudflare.Account, wg *sync.WaitGroup) {
@@ -408,6 +433,55 @@ func fetchWorkerAnalytics(account cloudflare.Account, wg *sync.WaitGroup) {
 			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "quantile": "P999"}).Set(float64(w.Quantiles.DurationP999))
 		}
 	}
+}
+
+func fetchLogpushAnalyticsForAccount(account cloudflare.Account, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
+	if cfgFreeTier {
+		return
+	}
+
+	r, err := fetchLogpushAccount(account.ID)
+
+	if err != nil {
+		return
+	}
+
+	for _, account := range r.Viewer.Accounts {
+		for _, LogpushHealthAdaptiveGroup := range account.LogpushHealthAdaptiveGroups {
+			logpushFailedJobsAccount.With(prometheus.Labels{"destination": LogpushHealthAdaptiveGroup.Dimensions.DestinationType, "job_id": strconv.Itoa(LogpushHealthAdaptiveGroup.Dimensions.JobId), "final": strconv.Itoa(LogpushHealthAdaptiveGroup.Dimensions.Final)}).Add(float64(LogpushHealthAdaptiveGroup.Count))
+		}
+	}
+
+}
+
+func fetchLogpushAnalyticsForZone(zones []cloudflare.Zone, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
+	if cfgFreeTier {
+		return
+	}
+
+	zoneIDs := extractZoneIDs(filterNonFreePlanZones(zones))
+	if len(zoneIDs) == 0 {
+		return
+	}
+
+	r, err := fetchLogpushZone(zoneIDs)
+
+	if err != nil {
+		return
+	}
+
+	for _, zone := range r.Viewer.Zones {
+		for _, LogpushHealthAdaptiveGroup := range zone.LogpushHealthAdaptiveGroups {
+			logpushFailedJobsZone.With(prometheus.Labels{"destination": LogpushHealthAdaptiveGroup.Dimensions.DestinationType, "job_id": strconv.Itoa(LogpushHealthAdaptiveGroup.Dimensions.JobId), "final": strconv.Itoa(LogpushHealthAdaptiveGroup.Dimensions.Final)}).Add(float64(LogpushHealthAdaptiveGroup.Count))
+		}
+	}
+
 }
 
 func fetchZoneColocationAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {


### PR DESCRIPTION
Hello, 

First of all thank you for this amazing exporter for Cloudflare metrics. We at Red Hat are already finding this very helpful. 

We have a use case to monitor Logpush job status with Cloudflare Logpush metrics as per [docs](https://developers.cloudflare.com/logs/get-started/alerts-and-analytics/). So we wanted to enhance this exporter to add this functionality and hoping others may find it useful.

I'm happy to work on the feedback as required, to adhere to best practices as deemed necessary. 

Thank you. 