### PR TITLE
Adding rule name tag to cloudflare_zone_firewall_events_count metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Required authentication scopes:
 - `Account.Account Analytics:Read` is required for Worker metrics
 - `Account Settings:Read` is required for Worker metrics (for listing accessible accounts, scraping all available
   Workers included in authentication scope)
+- `Firewall Services:Read` is required to fetch zone rule name for `cloudflare_zone_firewall_events_count` metric
+- `Account. Account Rulesets:Read` is required to fetch account rule name for `cloudflare_zone_firewall_events_count` metric
 
 To authenticate this way, only set `CF_API_TOKEN` (omit `CF_API_EMAIL` and `CF_API_KEY`)
 

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -267,6 +267,23 @@ func fetchFirewallRules(zoneId string) map[string]string {
 	for _, rule := range listOfRules {
 		firewallRulesMap[rule.ID] = rule.Description
 	}
+
+	listOfRulesets, err := api.ListZoneRulesets(ctx, zoneId)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, rulesetDesc := range listOfRulesets {
+		if rulesetDesc.Phase == "http_request_firewall_managed" {
+			ruleset, err := api.GetZoneRuleset(ctx, zoneId, rulesetDesc.ID)
+			if err != nil {
+				log.Fatal(err)
+			}
+			for _, rule := range ruleset.Rules {
+				firewallRulesMap[rule.ID] = rule.Description
+			}
+		}
+	}
+
 	return firewallRulesMap
 }
 


### PR DESCRIPTION
Hello everyone, 

The project seems excellent, thank you all for working on it!

While using it on our project, I noticed that `cloudflare_zone_firewall_events_count` metric doesn't bring much inside into what kind of events are 'processed' by the firewall. It is very insightful to have a rule name for each event. 

It is not possible to get this information across all zones in the Cloudflare dashboard, so it would be a great addition to the project. 