### PR TITLE
Add path metric

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -401,6 +401,7 @@ query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!, $htt
 
 	err := json.Unmarshal([]byte(cfgClientRequestPathFilters), &httpRequestsClientRequestPathFilter)
 	if err != nil {
+		log.Error(err)
 		return nil, err
 	}
 

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -388,7 +388,6 @@ query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!, $htt
 		}
 	}
 }`
-
 	request := graphql.NewRequest(query)
 	if len(cfgCfAPIToken) > 0 {
 		request.Header.Set("Authorization", "Bearer "+cfgCfAPIToken)
@@ -412,6 +411,12 @@ query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!, $htt
 			"datetime_lt":  now,
 		},
 	)
+
+	if log.DebugLevel == log.GetLevel() {
+		log.Debug(httpRequestsClientRequestPathFilter)
+		f, _ := json.Marshal(httpRequestsClientRequestPathFilter)
+		log.Debug(string(f))
+	}
 
 	request.Var("httpRequestsClientRequestPathFilter", httpRequestsClientRequestPathFilter)
 	request.Var("limit", 9999)

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/cloudflare/cloudflare-go"
@@ -156,6 +157,16 @@ type zoneResp struct {
 		} `json:"dimensions"`
 	} `json:"httpRequestsAdaptiveGroups"`
 
+	HTTPRequestsClientRequestPath []struct {
+		Count      uint64 `json:"count"`
+		Dimensions struct {
+			OriginResponseStatus        uint16 `json:"originResponseStatus"`
+			ClientRequestHTTPHost       string `json:"clientRequestHTTPHost"`
+			ClientRequestPath           string `json:"clientRequestPath"`
+			ClientRequestHTTPMethodName string `json:"clientRequestHTTPMethodName"`
+		} `json:"dimensions"`
+	} `json:"httpRequestsClientRequestPath"`
+
 	HTTPRequestsEdgeCountryHost []struct {
 		Count      uint64 `json:"count"`
 		Dimensions struct {
@@ -269,8 +280,8 @@ func fetchZoneTotals(zoneIDs []string) (*cloudflareResponse, error) {
 	now = now.Truncate(s)
 	now1mAgo := now.Add(-60 * time.Second)
 
-	request := graphql.NewRequest(`
-query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!) {
+	query := `
+query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!, $httpRequestsClientRequestPathFilter: ZoneHttpRequestsAdaptiveGroupsFilter_InputObject!) {
 	viewer {
 		zones(filter: { zoneTag_in: $zoneIDs }) {
 			zoneTag
@@ -342,6 +353,32 @@ query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!) {
 					originResponseStatus
 					clientCountryName
 					clientRequestHTTPHost
+		
+				}
+			}
+			httpRequestsClientRequestPath: httpRequestsAdaptiveGroups(
+				limit: 100, 
+				filter: $httpRequestsClientRequestPathFilter,
+				orderBy: [count_DESC]) 
+			{
+				count
+				avg {
+					originResponseDurationMs
+					sampleInterval
+				}
+				ratio {
+					status4xx
+					status5xx
+				}
+				sum {
+					edgeResponseBytes
+					visits
+				}
+				dimensions {
+					originResponseStatus
+					clientRequestPath
+					clientRequestHTTPHost
+					clientRequestHTTPMethodName
 				}
 			}
 			httpRequestsEdgeCountryHost: httpRequestsAdaptiveGroups(limit: $limit, filter: { datetime_geq: $mintime, datetime_lt: $maxtime }) {
@@ -363,14 +400,32 @@ query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!) {
 			}
 		}
 	}
-}
-`)
+}`
+
+	request := graphql.NewRequest(query)
 	if len(cfgCfAPIToken) > 0 {
 		request.Header.Set("Authorization", "Bearer "+cfgCfAPIToken)
 	} else {
 		request.Header.Set("X-AUTH-EMAIL", cfgCfAPIEmail)
 		request.Header.Set("X-AUTH-KEY", cfgCfAPIKey)
 	}
+
+	var httpRequestsClientRequestPathFilter map[string]interface{}
+
+	err := json.Unmarshal([]byte(cfgClientRequestPathFilters), &httpRequestsClientRequestPathFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	httpRequestsClientRequestPathFilter["AND"] = append(
+		httpRequestsClientRequestPathFilter["AND"].([]interface{}),
+		map[string]time.Time{
+			"datetime_geq": now1mAgo,
+			"datetime_lt":  now,
+		},
+	)
+
+	request.Var("httpRequestsClientRequestPathFilter", httpRequestsClientRequestPathFilter)
 	request.Var("limit", 9999)
 	request.Var("maxtime", now)
 	request.Var("mintime", now1mAgo)

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -353,27 +353,14 @@ query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!, $htt
 					originResponseStatus
 					clientCountryName
 					clientRequestHTTPHost
-		
 				}
 			}
 			httpRequestsClientRequestPath: httpRequestsAdaptiveGroups(
-				limit: 100, 
+				limit: $limit,
 				filter: $httpRequestsClientRequestPathFilter,
-				orderBy: [count_DESC]) 
-			{
+				orderBy: [count_DESC]
+			) {
 				count
-				avg {
-					originResponseDurationMs
-					sampleInterval
-				}
-				ratio {
-					status4xx
-					status5xx
-				}
-				sum {
-					edgeResponseBytes
-					visits
-				}
 				dimensions {
 					originResponseStatus
 					clientRequestPath

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 	cfgBatchSize                = 10
 	cfgMetricsDenylist          = ""
 	cfgClientRequestPathFilters = ""
+	cfgLogLevel                 = "info"
 )
 
 func getTargetZones() []string {
@@ -143,6 +144,7 @@ func main() {
 	flag.StringVar(&cfgClientRequestPathFilters, "cf_path_filters", cfgClientRequestPathFilters, "add filters to path query")
 	flag.BoolVar(&cfgFreeTier, "free_tier", cfgFreeTier, "scrape only metrics included in free plan")
 	flag.StringVar(&cfgMetricsDenylist, "metrics_denylist", cfgMetricsDenylist, "metrics to not expose, comma delimited list")
+	flag.StringVar(&cfgLogLevel, "log_level", cfgLogLevel, "log level, defaults to info")
 
 	flag.Parse()
 	if !(len(cfgCfAPIToken) > 0 || (len(cfgCfAPIEmail) > 0 && len(cfgCfAPIKey) > 0)) {
@@ -155,6 +157,16 @@ func main() {
 	customFormatter.TimestampFormat = "2006-01-02 15:04:05"
 	log.SetFormatter(customFormatter)
 	customFormatter.FullTimestamp = true
+
+	log_level, err := log.ParseLevel(cfgLogLevel)
+	if err != nil {
+		log_level = log.InfoLevel
+	}
+
+	log.SetLevel(log_level)
+	log.WithFields(log.Fields{
+		"log_level": log_level,
+	}).Info()
 
 	metricsDenylist := []string{}
 	if len(cfgMetricsDenylist) > 0 {

--- a/main.go
+++ b/main.go
@@ -15,17 +15,18 @@ import (
 )
 
 var (
-	cfgListen          = ":8080"
-	cfgCfAPIKey        = ""
-	cfgCfAPIEmail      = ""
-	cfgCfAPIToken      = ""
-	cfgMetricsPath     = "/metrics"
-	cfgZones           = ""
-	cfgExcludeZones    = ""
-	cfgScrapeDelay     = 300
-	cfgFreeTier        = false
-	cfgBatchSize       = 10
-	cfgMetricsDenylist = ""
+	cfgListen                   = ":8080"
+	cfgCfAPIKey                 = ""
+	cfgCfAPIEmail               = ""
+	cfgCfAPIToken               = ""
+	cfgMetricsPath              = "/metrics"
+	cfgZones                    = ""
+	cfgExcludeZones             = ""
+	cfgScrapeDelay              = 300
+	cfgFreeTier                 = false
+	cfgBatchSize                = 10
+	cfgMetricsDenylist          = ""
+	cfgClientRequestPathFilters = ""
 )
 
 func getTargetZones() []string {
@@ -139,8 +140,10 @@ func main() {
 	flag.StringVar(&cfgExcludeZones, "cf_exclude_zones", cfgExcludeZones, "cloudflare zones to exclude, comma delimited list")
 	flag.IntVar(&cfgScrapeDelay, "scrape_delay", cfgScrapeDelay, "scrape delay in seconds, defaults to 300")
 	flag.IntVar(&cfgBatchSize, "cf_batch_size", cfgBatchSize, "cloudflare zones batch size (1-10), defaults to 10")
+	flag.StringVar(&cfgClientRequestPathFilters, "cf_path_filters", cfgClientRequestPathFilters, "add filters to path query")
 	flag.BoolVar(&cfgFreeTier, "free_tier", cfgFreeTier, "scrape only metrics included in free plan")
 	flag.StringVar(&cfgMetricsDenylist, "metrics_denylist", cfgMetricsDenylist, "metrics to not expose, comma delimited list")
+
 	flag.Parse()
 	if !(len(cfgCfAPIToken) > 0 || (len(cfgCfAPIEmail) > 0 && len(cfgCfAPIKey) > 0)) {
 		log.Fatal("Please provide CF_API_KEY+CF_API_EMAIL or CF_API_TOKEN")


### PR DESCRIPTION
# New Cloudflare metric and configuration option

This pull request adds a new metric, `cloudflare_zone_requests_origin_status_path_host`, to the exporter. The new metric takes the path from Cloudflare's GraphQL endpoint `httpRequestsAdaptiveGroups`.

To enable this new metric, a new configuration option cfgClientRequestPathFilters has been added, which allows the user to pass a filter to specify which requests should be included in the metric. For example, to filter requests based on their HTTP host and path, the following command line argument can be used:

```
-cf_path_filters='{ "AND": [ { "clientRequestHTTPHost_in": [ "foo.io" ] }, {"clientRequestPath_in": [ "/bar", "/bar/foo" ] } ] }'
```

The filter should match the filter of `httpRequestsAdaptiveGroups` and the default datetime will be added

This filter will only include requests that have an HTTP host of foo.io and a path of either /bar or /bar/foo.

This new feature provides users of cloudflare-exporter with greater flexibility in monitoring and analyzing requests from specific origins.

### Notes

- This should address #33
- I choose this approach to not flood prometheus with metrics, I noticed that even if I get the top x metrics, this number tend to grown as they rotate, found much safer to  just pass the query and give the option to use filters like `clientRequestPath_in`
