### PR TITLE
Allow custom labels

### DIFF
--- a/charts/cloudflare-exporter/Chart.yaml
+++ b/charts/cloudflare-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cloudflare-exporter
-version: 0.1.9
+version: 0.2.0
 appVersion: 0.0.9
 home: https://github.com/lablabs/cloudflare-exporter
 description: A Helm chart for cloudflare exporter

--- a/charts/cloudflare-exporter/templates/_helpers.tpl
+++ b/charts/cloudflare-exporter/templates/_helpers.tpl
@@ -36,6 +36,11 @@ Common labels
 {{- define "cloudflare-exporter.labels" -}}
 helm.sh/chart: {{ include "cloudflare-exporter.chart" . }}
 {{ include "cloudflare-exporter.selectorLabels" . }}
+{{- if .Values.labels }}
+{{- range $key, $value := .Values.labels }}
+{{ $key }}: "{{ $value }}"
+{{- end }}
+{{- end }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}

--- a/charts/cloudflare-exporter/templates/deployment.yaml
+++ b/charts/cloudflare-exporter/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       labels:
-        {{- include "cloudflare-exporter.selectorLabels" . | nindent 8 }}
+        {{- include "cloudflare-exporter.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Hey there, 

We depend on upstream helm charts that we pull into our environment. We also leverage custom labels for a lot of reasons and also have Kyverno (k8s policy tool) checking for specific labels.

This PR should allow people to add/create custom labels for their charts.