### PR TITLE
Don't collect excluded metrics at all

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func filterExcludedZones(all []cloudflare.Zone, exclude []string) []cloudflare.Z
 	return filtered
 }
 
-func fetchMetrics() {
+func fetchMetrics(deniedMetricsSet MetricsSet) {
 	var wg sync.WaitGroup
 	zones := fetchZones()
 	accounts := fetchAccounts()
@@ -121,9 +121,9 @@ func fetchMetrics() {
 		targetZones := filteredZones[:sliceLength]
 		filteredZones = filteredZones[len(targetZones):]
 
-		go fetchZoneAnalytics(targetZones, &wg)
-		go fetchZoneColocationAnalytics(targetZones, &wg)
-		go fetchLoadBalancerAnalytics(targetZones, &wg)
+		go fetchZoneAnalytics(targetZones, &wg, deniedMetricsSet)
+		go fetchZoneColocationAnalytics(targetZones, &wg, deniedMetricsSet)
+		go fetchLoadBalancerAnalytics(targetZones, &wg, deniedMetricsSet)
 	}
 
 	wg.Wait()
@@ -165,7 +165,7 @@ func main() {
 
 	go func() {
 		for ; true; <-time.NewTicker(60 * time.Second).C {
-			go fetchMetrics()
+			go fetchMetrics(deniedMetricsSet)
 		}
 	}()
 


### PR DESCRIPTION
## What?

Only create metrics that are not in the deny list.

## Why?

Currently the deny list only applies to what is exposed in the `/metrics` endpoint but all metrics are collected internally regardless of if they are being reported or not. If you have a lot of sites in Cloudflare the high cardinality of the metrics causes them to use a lot of memory. I've seen the exporter use over 2GB of memory even when excluding most of the metrics.

This change fixes that by passing the deny list down into the functions that collect the data and create the metrics so that it will only create new counters for a metric if it is not in the deny list.

I've tested this change on a large site with most metrics excluded and have observed a dramatic reduction in memory usage.

Would be great to get this into your repo so that everyone using the cloudflare_exporter can benefit. Please let me know if you need more proofs of working, have feedback, etc.