### PR TITLE
Add Account Label to Metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 
 RUN go get -d -v
-RUN CGO_ENABLED=0 GOOS=linux go build -o cloudflare_exporter .
+RUN CGO_ENABLED=0 GOOS=linux go build --ldflags '-w -s -extldflags "-static"' -o cloudflare_exporter .
 
 FROM alpine:3.17
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: build
 build:
-	CGO_ENABLED=0 go build -o cloudflare_exporter .
+	CGO_ENABLED=0 go build --ldflags '-w -s -extldflags "-static"' -o cloudflare_exporter .

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"context"
+	"strings"
 	"time"
 
-	"github.com/cloudflare/cloudflare-go"
+	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/machinebox/graphql"
 	log "github.com/sirupsen/logrus"
 )
@@ -579,14 +580,14 @@ func fetchLoadBalancerTotals(zoneIDs []string) (*cloudflareResponseLb, error) {
 	return &resp, nil
 }
 
-func findZoneName(zones []cloudflare.Zone, ID string) string {
+func findZoneAccountName(zones []cloudflare.Zone, ID string) (string, string) {
 	for _, z := range zones {
 		if z.ID == ID {
-			return z.Name
+			return z.Name, strings.ToLower(strings.ReplaceAll(z.Account.Name, " ", "-"))
 		}
 	}
 
-	return ""
+	return "", ""
 }
 
 func extractZoneIDs(zones []cloudflare.Zone) []string {

--- a/main.go
+++ b/main.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cloudflare/cloudflare-go"
+	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/namsral/flag"
-	"github.com/nelkinda/health-go"
+	health "github.com/nelkinda/health-go"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 )

--- a/prometheus.go
+++ b/prometheus.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/biter777/countries"
@@ -65,183 +66,183 @@ var (
 	zoneRequestTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneRequestTotalMetricName.String(),
 		Help: "Number of requests for zone",
-	}, []string{"zone"},
+	}, []string{"zone", "account"},
 	)
 
 	zoneRequestCached = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneRequestCachedMetricName.String(),
 		Help: "Number of cached requests for zone",
-	}, []string{"zone"},
+	}, []string{"zone", "account"},
 	)
 
 	zoneRequestSSLEncrypted = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneRequestSSLEncryptedMetricName.String(),
 		Help: "Number of encrypted requests for zone",
-	}, []string{"zone"},
+	}, []string{"zone", "account"},
 	)
 
 	zoneRequestContentType = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneRequestContentTypeMetricName.String(),
 		Help: "Number of request for zone per content type",
-	}, []string{"zone", "content_type"},
+	}, []string{"zone", "account", "content_type"},
 	)
 
 	zoneRequestCountry = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneRequestCountryMetricName.String(),
 		Help: "Number of request for zone per country",
-	}, []string{"zone", "country", "region"},
+	}, []string{"zone", "account", "country", "region"},
 	)
 
 	zoneRequestHTTPStatus = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneRequestHTTPStatusMetricName.String(),
 		Help: "Number of request for zone per HTTP status",
-	}, []string{"zone", "status"},
+	}, []string{"zone", "account", "status"},
 	)
 
 	zoneRequestBrowserMap = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneRequestBrowserMapMetricName.String(),
 		Help: "Number of successful requests for HTML pages per zone",
-	}, []string{"zone", "family"},
+	}, []string{"zone", "account", "family"},
 	)
 
 	zoneRequestOriginStatusCountryHost = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneRequestOriginStatusCountryHostMetricName.String(),
 		Help: "Count of not cached requests for zone per origin HTTP status per country per host",
-	}, []string{"zone", "status", "country", "host"},
+	}, []string{"zone", "account", "status", "country", "host"},
 	)
 
 	zoneRequestStatusCountryHost = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneRequestStatusCountryHostMetricName.String(),
 		Help: "Count of requests for zone per edge HTTP status per country per host",
-	}, []string{"zone", "status", "country", "host"},
+	}, []string{"zone", "account", "status", "country", "host"},
 	)
 
 	zoneBandwidthTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneBandwidthTotalMetricName.String(),
 		Help: "Total bandwidth per zone in bytes",
-	}, []string{"zone"},
+	}, []string{"zone", "account"},
 	)
 
 	zoneBandwidthCached = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneBandwidthCachedMetricName.String(),
 		Help: "Cached bandwidth per zone in bytes",
-	}, []string{"zone"},
+	}, []string{"zone", "account"},
 	)
 
 	zoneBandwidthSSLEncrypted = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneBandwidthSSLEncryptedMetricName.String(),
 		Help: "Encrypted bandwidth per zone in bytes",
-	}, []string{"zone"},
+	}, []string{"zone", "account"},
 	)
 
 	zoneBandwidthContentType = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneBandwidthContentTypeMetricName.String(),
 		Help: "Bandwidth per zone per content type",
-	}, []string{"zone", "content_type"},
+	}, []string{"zone", "account", "content_type"},
 	)
 
 	zoneBandwidthCountry = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneBandwidthCountryMetricName.String(),
 		Help: "Bandwidth per country per zone",
-	}, []string{"zone", "country", "region"},
+	}, []string{"zone", "account", "country", "region"},
 	)
 
 	zoneThreatsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneThreatsTotalMetricName.String(),
 		Help: "Threats per zone",
-	}, []string{"zone"},
+	}, []string{"zone", "account"},
 	)
 
 	zoneThreatsCountry = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneThreatsCountryMetricName.String(),
 		Help: "Threats per zone per country",
-	}, []string{"zone", "country", "region"},
+	}, []string{"zone", "account", "country", "region"},
 	)
 
 	zoneThreatsType = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneThreatsTypeMetricName.String(),
 		Help: "Threats per zone per type",
-	}, []string{"zone", "type"},
+	}, []string{"zone", "account", "type"},
 	)
 
 	zonePageviewsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zonePageviewsTotalMetricName.String(),
 		Help: "Pageviews per zone",
-	}, []string{"zone"},
+	}, []string{"zone", "account"},
 	)
 
 	zoneUniquesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneUniquesTotalMetricName.String(),
 		Help: "Uniques per zone",
-	}, []string{"zone"},
+	}, []string{"zone", "account"},
 	)
 
 	zoneColocationVisits = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneColocationVisitsMetricName.String(),
 		Help: "Total visits per colocation",
-	}, []string{"zone", "colocation", "host"},
+	}, []string{"zone", "account", "colocation", "host"},
 	)
 
 	zoneColocationEdgeResponseBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneColocationEdgeResponseBytesMetricName.String(),
 		Help: "Edge response bytes per colocation",
-	}, []string{"zone", "colocation", "host"},
+	}, []string{"zone", "account", "colocation", "host"},
 	)
 
 	zoneColocationRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneColocationRequestsTotalMetricName.String(),
 		Help: "Total requests per colocation",
-	}, []string{"zone", "colocation", "host"},
+	}, []string{"zone", "account", "colocation", "host"},
 	)
 
 	zoneFirewallEventsCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneFirewallEventsCountMetricName.String(),
 		Help: "Count of Firewall events",
-	}, []string{"zone", "action", "source", "host", "country"},
+	}, []string{"zone", "account", "action", "source", "host", "country"},
 	)
 
 	zoneHealthCheckEventsOriginCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneHealthCheckEventsOriginCountMetricName.String(),
 		Help: "Number of Heath check events per region per origin",
-	}, []string{"zone", "health_status", "origin_ip", "region", "fqdn"},
+	}, []string{"zone", "account", "health_status", "origin_ip", "region", "fqdn"},
 	)
 
 	workerRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: workerRequestsMetricName.String(),
 		Help: "Number of requests sent to worker by script name",
-	}, []string{"script_name"},
+	}, []string{"script_name", "account"},
 	)
 
 	workerErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: workerErrorsMetricName.String(),
 		Help: "Number of errors by script name",
-	}, []string{"script_name"},
+	}, []string{"script_name", "account"},
 	)
 
 	workerCPUTime = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: workerCPUTimeMetricName.String(),
 		Help: "CPU time quantiles by script name",
-	}, []string{"script_name", "quantile"},
+	}, []string{"script_name", "account", "quantile"},
 	)
 
 	workerDuration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: workerDurationMetricName.String(),
 		Help: "Duration quantiles by script name (GB*s)",
-	}, []string{"script_name", "quantile"},
+	}, []string{"script_name", "account", "quantile"},
 	)
 
 	poolHealthStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: poolHealthStatusMetricName.String(),
 		Help: "Reports the health of a pool, 1 for healthy, 0 for unhealthy.",
 	},
-		[]string{"zone", "load_balancer_name", "pool_name"},
+		[]string{"zone", "account", "load_balancer_name", "pool_name"},
 	)
 
 	poolRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: poolRequestsTotalMetricName.String(),
 		Help: "Requests per pool",
 	},
-		[]string{"zone", "load_balancer_name", "pool_name", "origin_name"},
+		[]string{"zone", "account", "load_balancer_name", "pool_name", "origin_name"},
 	)
 )
 
@@ -394,18 +395,21 @@ func fetchWorkerAnalytics(account cloudflare.Account, wg *sync.WaitGroup) {
 		return
 	}
 
+	// Replace spaces with hyphens and convert to lowercase
+	accountName := strings.ToLower(strings.ReplaceAll(account.Name, " ", "-"))
+
 	for _, a := range r.Viewer.Accounts {
 		for _, w := range a.WorkersInvocationsAdaptive {
-			workerRequests.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName}).Add(float64(w.Sum.Requests))
-			workerErrors.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName}).Add(float64(w.Sum.Errors))
-			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "quantile": "P50"}).Set(float64(w.Quantiles.CPUTimeP50))
-			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "quantile": "P75"}).Set(float64(w.Quantiles.CPUTimeP75))
-			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "quantile": "P99"}).Set(float64(w.Quantiles.CPUTimeP99))
-			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "quantile": "P999"}).Set(float64(w.Quantiles.CPUTimeP999))
-			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "quantile": "P50"}).Set(float64(w.Quantiles.DurationP50))
-			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "quantile": "P75"}).Set(float64(w.Quantiles.DurationP75))
-			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "quantile": "P99"}).Set(float64(w.Quantiles.DurationP99))
-			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "quantile": "P999"}).Set(float64(w.Quantiles.DurationP999))
+			workerRequests.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName}).Add(float64(w.Sum.Requests))
+			workerErrors.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName}).Add(float64(w.Sum.Errors))
+			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P50"}).Set(float64(w.Quantiles.CPUTimeP50))
+			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P75"}).Set(float64(w.Quantiles.CPUTimeP75))
+			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P99"}).Set(float64(w.Quantiles.CPUTimeP99))
+			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P999"}).Set(float64(w.Quantiles.CPUTimeP999))
+			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P50"}).Set(float64(w.Quantiles.DurationP50))
+			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P75"}).Set(float64(w.Quantiles.DurationP75))
+			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P99"}).Set(float64(w.Quantiles.DurationP99))
+			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P999"}).Set(float64(w.Quantiles.DurationP999))
 		}
 	}
 }
@@ -432,11 +436,11 @@ func fetchZoneColocationAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 	for _, z := range r.Viewer.Zones {
 
 		cg := z.ColoGroups
-		name := findZoneName(zones, z.ZoneTag)
+		name, account := findZoneAccountName(zones, z.ZoneTag)
 		for _, c := range cg {
-			zoneColocationVisits.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Sum.Visits))
-			zoneColocationEdgeResponseBytes.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Sum.EdgeResponseBytes))
-			zoneColocationRequestsTotal.With(prometheus.Labels{"zone": name, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Count))
+			zoneColocationVisits.With(prometheus.Labels{"zone": name, "account": account, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Sum.Visits))
+			zoneColocationEdgeResponseBytes.With(prometheus.Labels{"zone": name, "account": account, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Sum.EdgeResponseBytes))
+			zoneColocationRequestsTotal.With(prometheus.Labels{"zone": name, "account": account, "colocation": c.Dimensions.ColoCode, "host": c.Dimensions.Host}).Add(float64(c.Count))
 		}
 	}
 }
@@ -461,64 +465,65 @@ func fetchZoneAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 	}
 
 	for _, z := range r.Viewer.Zones {
-		name := findZoneName(zones, z.ZoneTag)
-		addHTTPGroups(&z, name)
-		addFirewallGroups(&z, name)
-		addHealthCheckGroups(&z, name)
-		addHTTPAdaptiveGroups(&z, name)
+		name, account := findZoneAccountName(zones, z.ZoneTag)
+		addHTTPGroups(&z, name, account)
+		addFirewallGroups(&z, name, account)
+		addHealthCheckGroups(&z, name, account)
+		addHTTPAdaptiveGroups(&z, name, account)
 	}
 }
 
-func addHTTPGroups(z *zoneResp, name string) {
+func addHTTPGroups(z *zoneResp, name string, account string) {
 	// Nothing to do.
 	if len(z.HTTP1mGroups) == 0 {
 		return
 	}
+
 	zt := z.HTTP1mGroups[0]
 
-	zoneRequestTotal.With(prometheus.Labels{"zone": name}).Add(float64(zt.Sum.Requests))
-	zoneRequestCached.With(prometheus.Labels{"zone": name}).Add(float64(zt.Sum.CachedRequests))
-	zoneRequestSSLEncrypted.With(prometheus.Labels{"zone": name}).Add(float64(zt.Sum.EncryptedRequests))
+	zoneRequestTotal.With(prometheus.Labels{"zone": name, "account": account}).Add(float64(zt.Sum.Requests))
+	zoneRequestCached.With(prometheus.Labels{"zone": name, "account": account}).Add(float64(zt.Sum.CachedRequests))
+	zoneRequestSSLEncrypted.With(prometheus.Labels{"zone": name, "account": account}).Add(float64(zt.Sum.EncryptedRequests))
 
 	for _, ct := range zt.Sum.ContentType {
-		zoneRequestContentType.With(prometheus.Labels{"zone": name, "content_type": ct.EdgeResponseContentType}).Add(float64(ct.Requests))
-		zoneBandwidthContentType.With(prometheus.Labels{"zone": name, "content_type": ct.EdgeResponseContentType}).Add(float64(ct.Bytes))
+		zoneRequestContentType.With(prometheus.Labels{"zone": name, "account": account, "content_type": ct.EdgeResponseContentType}).Add(float64(ct.Requests))
+		zoneBandwidthContentType.With(prometheus.Labels{"zone": name, "account": account, "content_type": ct.EdgeResponseContentType}).Add(float64(ct.Bytes))
 	}
 
 	for _, country := range zt.Sum.Country {
 		c := countries.ByName(country.ClientCountryName)
 		region := c.Info().Region.Info().Name
 
-		zoneRequestCountry.With(prometheus.Labels{"zone": name, "country": country.ClientCountryName, "region": region}).Add(float64(country.Requests))
-		zoneBandwidthCountry.With(prometheus.Labels{"zone": name, "country": country.ClientCountryName, "region": region}).Add(float64(country.Bytes))
-		zoneThreatsCountry.With(prometheus.Labels{"zone": name, "country": country.ClientCountryName, "region": region}).Add(float64(country.Threats))
+		zoneRequestCountry.With(prometheus.Labels{"zone": name, "account": account, "country": country.ClientCountryName, "region": region}).Add(float64(country.Requests))
+		zoneBandwidthCountry.With(prometheus.Labels{"zone": name, "account": account, "country": country.ClientCountryName, "region": region}).Add(float64(country.Bytes))
+		zoneThreatsCountry.With(prometheus.Labels{"zone": name, "account": account, "country": country.ClientCountryName, "region": region}).Add(float64(country.Threats))
 	}
 
 	for _, status := range zt.Sum.ResponseStatus {
-		zoneRequestHTTPStatus.With(prometheus.Labels{"zone": name, "status": strconv.Itoa(status.EdgeResponseStatus)}).Add(float64(status.Requests))
+		zoneRequestHTTPStatus.With(prometheus.Labels{"zone": name, "account": account, "status": strconv.Itoa(status.EdgeResponseStatus)}).Add(float64(status.Requests))
 	}
 
 	for _, browser := range zt.Sum.BrowserMap {
-		zoneRequestBrowserMap.With(prometheus.Labels{"zone": name, "family": browser.UaBrowserFamily}).Add(float64(browser.PageViews))
+		zoneRequestBrowserMap.With(prometheus.Labels{"zone": name, "account": account, "family": browser.UaBrowserFamily}).Add(float64(browser.PageViews))
 	}
 
-	zoneBandwidthTotal.With(prometheus.Labels{"zone": name}).Add(float64(zt.Sum.Bytes))
-	zoneBandwidthCached.With(prometheus.Labels{"zone": name}).Add(float64(zt.Sum.CachedBytes))
-	zoneBandwidthSSLEncrypted.With(prometheus.Labels{"zone": name}).Add(float64(zt.Sum.EncryptedBytes))
+	zoneBandwidthTotal.With(prometheus.Labels{"zone": name, "account": account}).Add(float64(zt.Sum.Bytes))
+	zoneBandwidthCached.With(prometheus.Labels{"zone": name, "account": account}).Add(float64(zt.Sum.CachedBytes))
+	zoneBandwidthSSLEncrypted.With(prometheus.Labels{"zone": name, "account": account}).Add(float64(zt.Sum.EncryptedBytes))
 
-	zoneThreatsTotal.With(prometheus.Labels{"zone": name}).Add(float64(zt.Sum.Threats))
+	zoneThreatsTotal.With(prometheus.Labels{"zone": name, "account": account}).Add(float64(zt.Sum.Threats))
 
 	for _, t := range zt.Sum.ThreatPathing {
-		zoneThreatsType.With(prometheus.Labels{"zone": name, "type": t.Name}).Add(float64(t.Requests))
+		zoneThreatsType.With(prometheus.Labels{"zone": name, "account": account, "type": t.Name}).Add(float64(t.Requests))
 	}
 
-	zonePageviewsTotal.With(prometheus.Labels{"zone": name}).Add(float64(zt.Sum.PageViews))
+	zonePageviewsTotal.With(prometheus.Labels{"zone": name, "account": account}).Add(float64(zt.Sum.PageViews))
 
 	// Uniques
-	zoneUniquesTotal.With(prometheus.Labels{"zone": name}).Add(float64(zt.Unique.Uniques))
+	zoneUniquesTotal.With(prometheus.Labels{"zone": name, "account": account}).Add(float64(zt.Unique.Uniques))
 }
 
-func addFirewallGroups(z *zoneResp, name string) {
+func addFirewallGroups(z *zoneResp, name string, account string) {
 	// Nothing to do.
 	if len(z.FirewallEventsAdaptiveGroups) == 0 {
 		return
@@ -528,6 +533,7 @@ func addFirewallGroups(z *zoneResp, name string) {
 		zoneFirewallEventsCount.With(
 			prometheus.Labels{
 				"zone":    name,
+				"account": account,
 				"action":  g.Dimensions.Action,
 				"source":  g.Dimensions.Source,
 				"host":    g.Dimensions.ClientRequestHTTPHost,
@@ -536,7 +542,7 @@ func addFirewallGroups(z *zoneResp, name string) {
 	}
 }
 
-func addHealthCheckGroups(z *zoneResp, name string) {
+func addHealthCheckGroups(z *zoneResp, name string, account string) {
 	if len(z.HealthCheckEventsAdaptiveGroups) == 0 {
 		return
 	}
@@ -545,6 +551,7 @@ func addHealthCheckGroups(z *zoneResp, name string) {
 		zoneHealthCheckEventsOriginCount.With(
 			prometheus.Labels{
 				"zone":          name,
+				"account":       account,
 				"health_status": g.Dimensions.HealthStatus,
 				"origin_ip":     g.Dimensions.OriginIP,
 				"region":        g.Dimensions.Region,
@@ -553,12 +560,13 @@ func addHealthCheckGroups(z *zoneResp, name string) {
 	}
 }
 
-func addHTTPAdaptiveGroups(z *zoneResp, name string) {
+func addHTTPAdaptiveGroups(z *zoneResp, name string, account string) {
 
 	for _, g := range z.HTTPRequestsAdaptiveGroups {
 		zoneRequestOriginStatusCountryHost.With(
 			prometheus.Labels{
 				"zone":    name,
+				"account": account,
 				"status":  strconv.Itoa(int(g.Dimensions.OriginResponseStatus)),
 				"country": g.Dimensions.ClientCountryName,
 				"host":    g.Dimensions.ClientRequestHTTPHost,
@@ -569,6 +577,7 @@ func addHTTPAdaptiveGroups(z *zoneResp, name string) {
 		zoneRequestStatusCountryHost.With(
 			prometheus.Labels{
 				"zone":    name,
+				"account": account,
 				"status":  strconv.Itoa(int(g.Dimensions.EdgeResponseStatus)),
 				"country": g.Dimensions.ClientCountryName,
 				"host":    g.Dimensions.ClientRequestHTTPHost,
@@ -596,18 +605,19 @@ func fetchLoadBalancerAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 		return
 	}
 	for _, lb := range l.Viewer.Zones {
-		name := findZoneName(zones, lb.ZoneTag)
-		addLoadBalancingRequestsAdaptive(&lb, name)
-		addLoadBalancingRequestsAdaptiveGroups(&lb, name)
+		name, account := findZoneAccountName(zones, lb.ZoneTag)
+		addLoadBalancingRequestsAdaptive(&lb, name, account)
+		addLoadBalancingRequestsAdaptiveGroups(&lb, name, account)
 	}
 }
 
-func addLoadBalancingRequestsAdaptiveGroups(z *lbResp, name string) {
+func addLoadBalancingRequestsAdaptiveGroups(z *lbResp, name string, account string) {
 
 	for _, g := range z.LoadBalancingRequestsAdaptiveGroups {
 		poolRequestsTotal.With(
 			prometheus.Labels{
 				"zone":               name,
+				"account":            account,
 				"load_balancer_name": g.Dimensions.LbName,
 				"pool_name":          g.Dimensions.SelectedPoolName,
 				"origin_name":        g.Dimensions.SelectedOriginName,
@@ -615,13 +625,14 @@ func addLoadBalancingRequestsAdaptiveGroups(z *lbResp, name string) {
 	}
 }
 
-func addLoadBalancingRequestsAdaptive(z *lbResp, name string) {
+func addLoadBalancingRequestsAdaptive(z *lbResp, name string, account string) {
 
 	for _, g := range z.LoadBalancingRequestsAdaptive {
 		for _, p := range g.Pools {
 			poolHealthStatus.With(
 				prometheus.Labels{
 					"zone":               name,
+					"account":            account,
 					"load_balancer_name": g.LbName,
 					"pool_name":          p.PoolName,
 				}).Set(float64(p.Healthy))


### PR DESCRIPTION
This commit adds the Account label to the metrics label list. The Account label provides additional context to the metrics, allowing for better categorization and analysis of data. This change enhances the accuracy and granularity of the metrics collected.

- Added Account label to metrics
- Improved data categorization and analysis

P.S. I did this for my own purposes, but overall, I think it will be a useful improvement.