### PR TITLE
fix: CF_ZONES env var

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,8 +33,8 @@ import (
 func getTargetZones() []string {
 	var zoneIDs []string
 
-	if len(viper.GetString("cfg_zones")) > 0 {
-		zoneIDs = strings.Split(viper.GetString("cfg_zones"), ",")
+	if len(viper.GetString("cf_zones")) > 0 {
+		zoneIDs = strings.Split(viper.GetString("cf_zones"), ",")
 	} else {
 		// deprecated
 		for _, e := range os.Environ() {

--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -7,7 +7,7 @@ source .env
 # Test if we have cloudflare api/key variables configured.
 
 # Run cloudflare-exporter
-nohup ./cloudflare_exporter --listen="${baseUrl}" >/tmp/cloudflare-expoter-test.out 2>&1 &
+nohup ./cloudflare_exporter --listen="${baseUrl}" >/tmp/cloudflare-exporter-test.out 2>&1 &
 export pid=$!
 sleep 5
 


### PR DESCRIPTION
See https://github.com/lablabs/cloudflare-exporter/issues/118
Local testing of this build with CF_ZONES set worked as it did in 0.14
log from test below (with id/names altered)
```
cat  /tmp/cloudflare-exporter-test.out
time="2024-05-15 10:29:51" level=info msg="Beginning to serve metrics on localhost:8081/metrics"
time="2024-05-15 10:29:51" level=info msg="Filtering zone: 262dec4e02vfbc896edc49c71407e42d test-infra-dev.com"
```