### PR TITLE
doc: rewrite auth scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ The preferred way of authenticating is with an API token, for which the scope ca
 dashboard.
 
 Required authentication scopes:
-- `Analytics:Read` is required for zone-level metrics
-- `Account.Account Analytics:Read` is required for Worker metrics
-- `Account Settings:Read` is required for Worker metrics (for listing accessible accounts, scraping all available
-  Workers included in authentication scope)
-- `Firewall Services:Read` is required to fetch zone rule name for `cloudflare_zone_firewall_events_count` metric
-- `Account. Account Rulesets:Read` is required to fetch account rule name for `cloudflare_zone_firewall_events_count` metric
+
+| **Scope** | **Description** | **Permission** | **Required For** |
+|---|---|---|---|
+| `Zone` | `Analytics` | `Read` | Zone-level metrics |
+| `Account` | `Account Analytics` | `Read` | Worker metrics |
+| `Account` | `Settings` |  `Read` | Worker metrics (for listing accessible accounts, scraping all available Workers included in authentication scope)
+| `Zone` |  `Firewall Services` | `Read` | Fetch zone rule name for `cloudflare_zone_firewall_events_count` metric |
+| `Account` | `Account Rulesets` | `Read` | Fetch account rule name for `cloudflare_zone_firewall_events_count` metric |
 
 To authenticate this way, only set `CF_API_TOKEN` (omit `CF_API_EMAIL` and `CF_API_KEY`)
 


### PR DESCRIPTION
I rewrote the list of permissions in a table that exactly reflects the labels of the cloudflare panel input. It should be easier to report the correct values.

Example: `Firewall Services:Read` becomes

| `Zones` | `Firewall Services` | `Read` |