### PR TITLE
fix: Correct worker metrics to provide metrics across all dimensions

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -531,7 +531,6 @@ func fetchWorkerTotals(accountID string) (*cloudflareResponseAccts, error) {
 					dimensions {
 						scriptName
 						status
-						datetime
 					}
 
 					sum {

--- a/prometheus.go
+++ b/prometheus.go
@@ -213,25 +213,25 @@ var (
 	workerRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: workerRequestsMetricName.String(),
 		Help: "Number of requests sent to worker by script name",
-	}, []string{"script_name", "account"},
+	}, []string{"script_name", "account", "status"},
 	)
 
 	workerErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: workerErrorsMetricName.String(),
 		Help: "Number of errors by script name",
-	}, []string{"script_name", "account"},
+	}, []string{"script_name", "account", "status"},
 	)
 
 	workerCPUTime = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: workerCPUTimeMetricName.String(),
 		Help: "CPU time quantiles by script name",
-	}, []string{"script_name", "account", "quantile"},
+	}, []string{"script_name", "account", "status", "quantile"},
 	)
 
 	workerDuration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: workerDurationMetricName.String(),
 		Help: "Duration quantiles by script name (GB*s)",
-	}, []string{"script_name", "account", "quantile"},
+	}, []string{"script_name", "account", "status", "quantile"},
 	)
 
 	poolHealthStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -426,16 +426,16 @@ func fetchWorkerAnalytics(account cloudflare.Account, wg *sync.WaitGroup) {
 
 	for _, a := range r.Viewer.Accounts {
 		for _, w := range a.WorkersInvocationsAdaptive {
-			workerRequests.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName}).Add(float64(w.Sum.Requests))
-			workerErrors.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName}).Add(float64(w.Sum.Errors))
-			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P50"}).Set(float64(w.Quantiles.CPUTimeP50))
-			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P75"}).Set(float64(w.Quantiles.CPUTimeP75))
-			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P99"}).Set(float64(w.Quantiles.CPUTimeP99))
-			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P999"}).Set(float64(w.Quantiles.CPUTimeP999))
-			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P50"}).Set(float64(w.Quantiles.DurationP50))
-			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P75"}).Set(float64(w.Quantiles.DurationP75))
-			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P99"}).Set(float64(w.Quantiles.DurationP99))
-			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "quantile": "P999"}).Set(float64(w.Quantiles.DurationP999))
+			workerRequests.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "status": w.Dimensions.Status}).Add(float64(w.Sum.Requests))
+			workerErrors.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "status": w.Dimensions.Status}).Add(float64(w.Sum.Errors))
+			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "status": w.Dimensions.Status, "quantile": "P50"}).Set(float64(w.Quantiles.CPUTimeP50))
+			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "status": w.Dimensions.Status, "quantile": "P75"}).Set(float64(w.Quantiles.CPUTimeP75))
+			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "status": w.Dimensions.Status, "quantile": "P99"}).Set(float64(w.Quantiles.CPUTimeP99))
+			workerCPUTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "status": w.Dimensions.Status, "quantile": "P999"}).Set(float64(w.Quantiles.CPUTimeP999))
+			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "status": w.Dimensions.Status, "quantile": "P50"}).Set(float64(w.Quantiles.DurationP50))
+			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "status": w.Dimensions.Status, "quantile": "P75"}).Set(float64(w.Quantiles.DurationP75))
+			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "status": w.Dimensions.Status, "quantile": "P99"}).Set(float64(w.Quantiles.DurationP99))
+			workerDuration.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "status": w.Dimensions.Status, "quantile": "P999"}).Set(float64(w.Quantiles.DurationP999))
 		}
 	}
 }


### PR DESCRIPTION
We currently have `datetime` and `status` as dimensions for the CloudFlare Worker invocation metrics GraphQL query.

This causes CloudFlare workers to output a number of datapoints for each unique tuple of dimensions, i.e. across several `datetime`s and `status`es.

For worker requests and errors this is fine as we `.Add(...)` to those counters, but for quantiles we use `.Set(...)` which causes us to only export the last datapoint quantiles, which may not representative of the entire dataset.

Removing the `datetime` for the query provides pre-aggregated datapoints for us to process.

Further to this, `datetime` is not currently being captured in the response data structure.

---

`status` is a useful dimension to disambiguate internal errors and the impact on performance across them. This change adds `status` to all of the worker metrics exported to reflect that, and to ensure we're not only using a single datapoint.