### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ The preferred way of authenticating is with an API token, for which the scope ca
 dashboard.
 
 Required authentication scopes:
-- `Analytics:Read` is required for zone-level metrics
-- `Account.Account Analytics:Read` is required for Worker metrics
-- `Account Settings:Read` is required for Worker metrics (for listing accessible accounts, scraping all available
+- `Zone/Analytics:Read` is required for zone-level metrics
+- `Account/Account Analytics:Read` is required for Worker metrics
+- `Account/Account Settings:Read` is required for Worker metrics (for listing accessible accounts, scraping all available
   Workers included in authentication scope)
-- `Firewall Services:Read` is required to fetch zone rule name for `cloudflare_zone_firewall_events_count` metric
-- `Account. Account Rulesets:Read` is required to fetch account rule name for `cloudflare_zone_firewall_events_count` metric
+- `Zone/Firewall Services:Read` is required to fetch zone rule name for `cloudflare_zone_firewall_events_count` metric
+- `Account/Account Rulesets:Read` is required to fetch account rule name for `cloudflare_zone_firewall_events_count` metric
 
 To authenticate this way, only set `CF_API_TOKEN` (omit `CF_API_EMAIL` and `CF_API_KEY`)
 


### PR DESCRIPTION
Update the CF API Token section in the readme
I noticed these small changes were needed when setting up the exporter...
___
Zone/Analytics:Read is required for zone-level metrics
Account/Account Analytics:Read is required for Worker metrics
Account/Account Settings:Read is required for Worker metrics (for listing accessible accounts, scraping all available Workers included in authentication scope)
Zone/Firewall Services:Read is required to fetch zone rule name for cloudflare_zone_firewall_events_count metric
Account/Account Rulesets:Read is required to fetch account rule name for cloudflare_zone_firewall_events_count metric
___