### PR TITLE
:package: Resolve docker build deprecations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:alpine as builder
+# check=skip=SecretsUsedInArgOrEnv we're just set default here, not any secret data
+FROM golang:alpine AS builder
 
 WORKDIR /app
 
@@ -17,7 +18,7 @@ RUN apk update && apk add ca-certificates
 
 COPY --from=builder /app/cloudflare_exporter cloudflare_exporter
 
-ENV CF_API_KEY ""
-ENV CF_API_EMAIL ""
+ENV CF_API_KEY=""
+ENV CF_API_EMAIL=""
 
 ENTRYPOINT [ "./cloudflare_exporter" ]


### PR DESCRIPTION
```
 4 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 20)
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ENV "CF_API_KEY") (line 20)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 21)
```