### PR TITLE
feat(zone_firewall): Custom Firewall rule name metrics

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -310,6 +310,16 @@ func fetchFirewallRules(zoneID string) map[string]string {
 				firewallRulesMap[rule.ID] = rule.Description
 			}
 		}
+
+		if rulesetDesc.Phase == "http_request_firewall_custom" {
+			ruleset, err := api.GetRuleset(ctx, cloudflare.ZoneIdentifier(zoneID), rulesetDesc.ID)
+			if err != nil {
+				log.Fatal(err)
+			}
+			for _, rule := range ruleset.Rules {
+				firewallRulesMap[rule.ID] = rule.Description
+			}
+		}
 	}
 
 	return firewallRulesMap


### PR DESCRIPTION
This PR allows the exporter to get the Custom Firewall events from the Cloudflare API

Exposes under `cloudflare_zone_firewall_events_count` with the new source of `source="firewallCustom"`

Examples:

```
# HELP cloudflare_zone_firewall_events_count Count of Firewall events
# TYPE cloudflare_zone_firewall_events_count counter
cloudflare_zone_firewall_events_count{account="your-account-name",action="log",country="CA",host="your-domain.com",rule="naughty_bots",source="firewallCustom",zone="sub-zone.your-domain.com"} 1
cloudflare_zone_firewall_events_count{account="your-account-name",action="log",country="GB",host="your-domain.com",rule="block_requests_to_internal_app_paths",source="firewallCustom",zone="your-domain.com"} 8
cloudflare_zone_firewall_events_count{account="your-account-name",action="log",country="GB",host="your-domain.com",rule="block_requests_to_internal_app_paths",source="firewallCustom",zone="your-domain.com"} 5
cloudflare_zone_firewall_events_count{account="your-account-name",action="log",country="GB",host="your-domain.com",rule="block_requests_to_internal_app_paths",source="firewallCustom",zone="your-domain.com"} 1
```

