### PR TITLE
Add configurable scrape delay and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ The exporter can be configured using env variables or command flags.
 | `FREE_TIER` | (Optional) scrape only metrics included in free plan. Accepts `true` or `false`, default `false`. |
 | `LISTEN` |  listen on addr:port (default `:8080`), omit addr to listen on all interfaces |
 | `METRICS_PATH` |  path for metrics, default `/metrics` |
-| `SCRAPE_DELAY` | scrape delay in seconds, default `300` |
+| `SCRAPE_INTERVAL` | how often to query Cloudflare API in seconds, default `60` |
+| `SCRAPE_DELAY` | how far back to query data in seconds (to account for Cloudflare processing delay), default `300` |
 | `CF_BATCH_SIZE` | cloudflare request zones batch size (1 - 10), default `10` |
 | `METRICS_DENYLIST` | (Optional) cloudflare-exporter metrics to not export, comma delimited list of cloudflare-exporter metrics. If not set, all metrics are exported |
 | `ZONE_<NAME>` |  `DEPRECATED since 0.0.5` (optional) Zone ID. Add zones you want to scrape by adding env vars in this format. You can find the zone ids in Cloudflare dashboards. |
@@ -66,6 +67,7 @@ Corresponding flags:
   -free_tier=false: scrape only metrics included in free plan, default false
   -listen=":8080": listen on addr:port ( default :8080), omit addr to listen on all interfaces
   -metrics_path="/metrics": path for metrics, default /metrics
+  -scrape_interval=60: scrape interval in seconds, defaults to 60
   -scrape_delay=300: scrape delay in seconds, defaults to 300
   -cf_batch_size=10: cloudflare zones batch size (1-10)
   -metrics_denylist="": cloudflare-exporter metrics to not export, comma delimited list

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -455,7 +455,7 @@ query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!) {
 
 	var resp cloudflareResponse
 	if err := graphqlClient.Run(ctx, request, &resp); err != nil {
-		log.Error(err)
+		log.Fatal("GraphQL query failed for zone totals: ", err)
 		return nil, err
 	}
 
@@ -510,7 +510,7 @@ func fetchColoTotals(zoneIDs []string) (*cloudflareResponseColo, error) {
 	graphqlClient := graphql.NewClient(cfGraphQLEndpoint)
 	var resp cloudflareResponseColo
 	if err := graphqlClient.Run(ctx, request, &resp); err != nil {
-		log.Error(err)
+		log.Fatal("GraphQL query failed for colocation totals: ", err)
 		return nil, err
 	}
 
@@ -570,7 +570,7 @@ func fetchWorkerTotals(accountID string) (*cloudflareResponseAccts, error) {
 	graphqlClient := graphql.NewClient(cfGraphQLEndpoint)
 	var resp cloudflareResponseAccts
 	if err := graphqlClient.Run(ctx, request, &resp); err != nil {
-		log.Error(err)
+		log.Fatal("GraphQL query failed for worker totals: ", err)
 		return nil, err
 	}
 
@@ -647,7 +647,7 @@ func fetchLoadBalancerTotals(zoneIDs []string) (*cloudflareResponseLb, error) {
 	graphqlClient := graphql.NewClient(cfGraphQLEndpoint)
 	var resp cloudflareResponseLb
 	if err := graphqlClient.Run(ctx, request, &resp); err != nil {
-		log.Error(err)
+		log.Fatal("GraphQL query failed for load balancer totals: ", err)
 		return nil, err
 	}
 	return &resp, nil
@@ -699,7 +699,7 @@ func fetchLogpushAccount(accountID string) (*cloudflareResponseLogpushAccount, e
 	graphqlClient := graphql.NewClient(cfGraphQLEndpoint)
 	var resp cloudflareResponseLogpushAccount
 	if err := graphqlClient.Run(ctx, request, &resp); err != nil {
-		log.Error(err)
+		log.Fatal("GraphQL query failed for logpush account: ", err)
 		return nil, err
 	}
 	return &resp, nil
@@ -751,7 +751,7 @@ func fetchLogpushZone(zoneIDs []string) (*cloudflareResponseLogpushZone, error) 
 	graphqlClient := graphql.NewClient(cfGraphQLEndpoint)
 	var resp cloudflareResponseLogpushZone
 	if err := graphqlClient.Run(ctx, request, &resp); err != nil {
-		log.Error(err)
+		log.Fatal("GraphQL query failed for logpush zone: ", err)
 		return nil, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -167,7 +167,7 @@ func runExpoter() {
 	mustRegisterMetrics(deniedMetricsSet)
 
 	go func() {
-		for ; true; <-time.NewTicker(60 * time.Second).C {
+		for ; true; <-time.NewTicker(time.Duration(viper.GetInt("scrape_interval")) * time.Second).C {
 			go fetchMetrics()
 		}
 	}()
@@ -234,6 +234,10 @@ func main() {
 	flags.Int("scrape_delay", 300, "scrape delay in seconds, defaults to 300")
 	viper.BindEnv("scrape_delay")
 	viper.SetDefault("scrape_delay", 300)
+
+	flags.Int("scrape_interval", 60, "scrape interval in seconds, defaults to 60")
+	viper.BindEnv("scrape_interval")
+	viper.SetDefault("scrape_interval", 60)
 
 	flags.Int("cf_batch_size", 10, "cloudflare zones batch size (1-10), defaults to 10")
 	viper.BindEnv("cf_batch_size")


### PR DESCRIPTION
Hi,

This PR tries to make the exporter a bit more robust when it comes to error handling. It does that in two different ways

- Make sure we can tune the scrape delay to allow users with a large number of zones not to hit the Cloudflare GraphQL rate limit. This keeps the 60s default that was previously hardcoded but give more flexibility to the user
- Make sure the exporter exits with an error when it encounters issues with the API result it got from Cloudflare. This helps make sure the exporter is not left in a broken state where it runs but doesn't send requests anymore, and leaves it to the user to manage the exporter's lifecycle with their usual tools. 

I think overall that makes the exporter more reliable and configurable. Let me know if there's anything I should change.