### PR TITLE
Make querying interval configurable and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The exporter can be configured using env variables or command flags.
 | `LISTEN` |  listen on addr:port (default `:8080`), omit addr to listen on all interfaces |
 | `METRICS_PATH` |  path for metrics, default `/metrics` |
 | `SCRAPE_DELAY` | scrape delay in seconds, default `300` |
+| `SCRAPE_INTERVAL` | scrape interval in seconds (will query cloudflare every SCRAPE_INTERVAL seconds), default `60` |
 | `CF_BATCH_SIZE` | cloudflare request zones batch size (1 - 10), default `10` |
 | `METRICS_DENYLIST` | (Optional) cloudflare-exporter metrics to not export, comma delimited list of cloudflare-exporter metrics. If not set, all metrics are exported |
 | `ZONE_<NAME>` |  `DEPRECATED since 0.0.5` (optional) Zone ID. Add zones you want to scrape by adding env vars in this format. You can find the zone ids in Cloudflare dashboards. |
@@ -67,6 +68,7 @@ Corresponding flags:
   -listen=":8080": listen on addr:port ( default :8080), omit addr to listen on all interfaces
   -metrics_path="/metrics": path for metrics, default /metrics
   -scrape_delay=300: scrape delay in seconds, defaults to 300
+  -scrape_interval=60: scrape interval in seconds, defaults to 60
   -cf_batch_size=10: cloudflare zones batch size (1-10)
   -metrics_denylist="": cloudflare-exporter metrics to not export, comma delimited list
 ```

--- a/main.go
+++ b/main.go
@@ -166,8 +166,11 @@ func runExpoter() {
 	}
 	mustRegisterMetrics(deniedMetricsSet)
 
+	scrapeInterval := time.Duration(viper.GetInt("scrape_interval")) * time.Second
+	log.Info("Scrape interval set to ", scrapeInterval)
+
 	go func() {
-		for ; true; <-time.NewTicker(60 * time.Second).C {
+		for ; true; <-time.NewTicker(scrapeInterval).C {
 			go fetchMetrics()
 		}
 	}()
@@ -233,6 +236,10 @@ func main() {
 	flags.Int("scrape_delay", 300, "scrape delay in seconds, defaults to 300")
 	viper.BindEnv("scrape_delay")
 	viper.SetDefault("scrape_delay", 300)
+
+	flags.Int("scrape_interval", 60, "scrape interval in seconds, defaults to 60")
+	viper.BindEnv("scrape_interval")
+	viper.SetDefault("scrape_interval", 60)
 
 	flags.Int("cf_batch_size", 10, "cloudflare zones batch size (1-10), defaults to 10")
 	viper.BindEnv("cf_batch_size")

--- a/prometheus.go
+++ b/prometheus.go
@@ -9,6 +9,7 @@ import (
 	"github.com/biter777/countries"
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -418,6 +419,7 @@ func fetchWorkerAnalytics(account cloudflare.Account, wg *sync.WaitGroup) {
 
 	r, err := fetchWorkerTotals(account.ID)
 	if err != nil {
+		log.Error("failed to fetch worker analytics for account ", account.ID, ": ", err)
 		return
 	}
 
@@ -451,6 +453,7 @@ func fetchLogpushAnalyticsForAccount(account cloudflare.Account, wg *sync.WaitGr
 	r, err := fetchLogpushAccount(account.ID)
 
 	if err != nil {
+		log.Error("failed to fetch logpush analytics for account ", account.ID, ": ", err)
 		return
 	}
 
@@ -480,6 +483,7 @@ func fetchLogpushAnalyticsForZone(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 	r, err := fetchLogpushZone(zoneIDs)
 
 	if err != nil {
+		log.Error("failed to fetch logpush analytics for zones: ", err)
 		return
 	}
 
@@ -508,6 +512,7 @@ func fetchZoneColocationAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 
 	r, err := fetchColoTotals(zoneIDs)
 	if err != nil {
+		log.Error("failed to fetch colocation analytics for zones: ", err)
 		return
 	}
 	for _, z := range r.Viewer.Zones {
@@ -537,6 +542,7 @@ func fetchZoneAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 
 	r, err := fetchZoneTotals(zoneIDs)
 	if err != nil {
+		log.Error("failed to fetch zone analytics: ", err)
 		return
 	}
 
@@ -688,6 +694,7 @@ func fetchLoadBalancerAnalytics(zones []cloudflare.Zone, wg *sync.WaitGroup) {
 
 	l, err := fetchLoadBalancerTotals(zoneIDs)
 	if err != nil {
+		log.Error("failed to fetch load balancer analytics: ", err)
 		return
 	}
 	for _, lb := range l.Viewer.Zones {


### PR DESCRIPTION
Hi,

This PR tries to make the exporter a bit more robust when it comes to error handling. It does that in two different ways

Make sure we can tune the scrape delay to allow users with a large number of zones not to hit the Cloudflare GraphQL rate limit. This keeps the 60s default that was previously hardcoded but give more flexibility to the user
Make sure the exporter exits with an error when it encounters issues with the API result it got from Cloudflare. This helps make sure the exporter is not left in a broken state where it runs but doesn't send requests anymore, and leaves it to the user to manage the exporter's lifecycle with their usual tools.
I think overall that makes the exporter more reliable and configurable. Let me know if there's anything I should change.