### PR TITLE
fix: Remove fatal errors outside main.go to improve flexibility

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -283,7 +283,8 @@ func fetchZones() []cloudflare.Zone {
 	ctx := context.Background()
 	z, err := cloudflareAPI.ListZones(ctx)
 	if err != nil {
-		log.Fatalf("Error fetching zones: %s", err)
+		log.Errorf("Error fetching zones: %s", err)
+		return nil
 	}
 
 	return z
@@ -295,7 +296,8 @@ func fetchFirewallRules(zoneID string) map[string]string {
 		cloudflare.ZoneIdentifier(zoneID),
 		cloudflare.FirewallRuleListParams{})
 	if err != nil {
-		log.Fatalf("Error fetching firewall rules: %s", err)
+		log.Errorf("Error fetching firewall rules: %s", err)
+		return nil
 	}
 	firewallRulesMap := make(map[string]string)
 
@@ -305,13 +307,15 @@ func fetchFirewallRules(zoneID string) map[string]string {
 
 	listOfRulesets, err := cloudflareAPI.ListRulesets(ctx, cloudflare.ZoneIdentifier(zoneID), cloudflare.ListRulesetsParams{})
 	if err != nil {
-		log.Fatalf("Error listing rulesets: %s", err)
+		log.Errorf("Error listing rulesets: %s", err)
+		return nil
 	}
 	for _, rulesetDesc := range listOfRulesets {
 		if rulesetDesc.Phase == "http_request_firewall_managed" {
 			ruleset, err := cloudflareAPI.GetRuleset(ctx, cloudflare.ZoneIdentifier(zoneID), rulesetDesc.ID)
 			if err != nil {
-				log.Fatalf("Error fetching ruleset for firewall rules: %s", err)
+				log.Errorf("Error fetching ruleset for firewall rules: %s", err)
+				return nil
 			}
 			for _, rule := range ruleset.Rules {
 				firewallRulesMap[rule.ID] = rule.Description
@@ -321,7 +325,8 @@ func fetchFirewallRules(zoneID string) map[string]string {
 		if rulesetDesc.Phase == "http_request_firewall_custom" {
 			ruleset, err := cloudflareAPI.GetRuleset(ctx, cloudflare.ZoneIdentifier(zoneID), rulesetDesc.ID)
 			if err != nil {
-				log.Fatalf("Error fetching custom firewall rulesets: %s", err)
+				log.Errorf("Error fetching custom firewall rulesets: %s", err)
+				return nil
 			}
 			for _, rule := range ruleset.Rules {
 				firewallRulesMap[rule.ID] = rule.Description
@@ -336,7 +341,8 @@ func fetchAccounts() []cloudflare.Account {
 	ctx := context.Background()
 	a, _, err := cloudflareAPI.Accounts(ctx, cloudflare.AccountsListParams{PaginationOptions: cloudflare.PaginationOptions{PerPage: 100}})
 	if err != nil {
-		log.Fatalf("Error fetching accounts: %s", err)
+		log.Errorf("Error fetching accounts: %s", err)
+		return nil
 	}
 
 	return a


### PR DESCRIPTION
## Pull Request Template

### Description
Ran into an issue where I could not grant all the permissions needed for the exporter and only really needed a subset of the metrics. The exporter always attempts to fetch most of the metrics from CF. For some of these the fetching functions would fatally exit the program. This seems a bit aggressive. The choice was either allow the error and carry on or add more flags/options to control which metrics are actually fetched. Removing the fatal errors seemed like the better option.

- Remove all fatal errors outside main.go (in cloudflare.go)
- Errors now log followed by `nil` return values for slices/maps which calling code handles

I consider this more of a bug fix, but if you were relying on this to fatal exit for these cases then it would be breaking.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

### Testing
~- [ ] I have run `make release-tests` and all tests pass~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Code Quality
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

### Before Submitting
Please ensure you have completed the following before submitting your PR:

```bash
# Run comprehensive tests
make release-tests
```

If the above command fails, please fix the issues before submitting your PR.

### Additional Notes
Some of these items in the PR template don't really apply or do not exist in this repo.