### PR TITLE
Fix race condition where Add was run within the callee instead of caller

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,10 +108,19 @@ func fetchMetrics() {
 	accounts := fetchAccounts()
 
 	for _, a := range accounts {
+		wg.Add(1)
 		go fetchWorkerAnalytics(a, &wg)
+
+		wg.Add(1)
 		go fetchLogpushAnalyticsForAccount(a, &wg)
+
+		wg.Add(1)
 		go fetchR2StorageForAccount(a, &wg)
+
+		wg.Add(1)
 		go fetchLoadblancerPoolsHealth(a, &wg)
+
+		wg.Add(1)
 		go fetchZeroTrustAnalyticsForAccount(a, &wg)
 	}
 
@@ -126,9 +135,16 @@ func fetchMetrics() {
 
 	zoneCount := len(filteredZones)
 	if zoneCount > 0 && zoneCount <= cfgraphqlreqlimit {
+		wg.Add(1)
 		go fetchZoneAnalytics(filteredZones, &wg)
+
+		wg.Add(1)
 		go fetchZoneColocationAnalytics(filteredZones, &wg)
+
+		wg.Add(1)
 		go fetchLoadBalancerAnalytics(filteredZones, &wg)
+
+		wg.Add(1)
 		go fetchLogpushAnalyticsForZone(filteredZones, &wg)
 	} else if zoneCount > cfgraphqlreqlimit {
 		for s := 0; s < zoneCount; s += cfgraphqlreqlimit {
@@ -136,9 +152,16 @@ func fetchMetrics() {
 			if e > zoneCount {
 				e = zoneCount
 			}
+			wg.Add(1)
 			go fetchZoneAnalytics(filteredZones[s:e], &wg)
+
+			wg.Add(1)
 			go fetchZoneColocationAnalytics(filteredZones[s:e], &wg)
+
+			wg.Add(1)
 			go fetchLoadBalancerAnalytics(filteredZones[s:e], &wg)
+
+			wg.Add(1)
 			go fetchLogpushAnalyticsForZone(filteredZones[s:e], &wg)
 		}
 	}

--- a/prometheus.go
+++ b/prometheus.go
@@ -496,7 +496,6 @@ func mustRegisterMetrics(deniedMetrics MetricsSet) {
 }
 
 func fetchLoadblancerPoolsHealth(account cfaccounts.Account, wg *sync.WaitGroup) {
-	wg.Add(1)
 	defer wg.Done()
 
 	pools := fetchLoadblancerPools(account)
@@ -531,7 +530,6 @@ func fetchLoadblancerPoolsHealth(account cfaccounts.Account, wg *sync.WaitGroup)
 }
 
 func fetchWorkerAnalytics(account cfaccounts.Account, wg *sync.WaitGroup) {
-	wg.Add(1)
 	defer wg.Done()
 
 	r, err := fetchWorkerTotals(account.ID)
@@ -560,7 +558,6 @@ func fetchWorkerAnalytics(account cfaccounts.Account, wg *sync.WaitGroup) {
 }
 
 func fetchLogpushAnalyticsForAccount(account cfaccounts.Account, wg *sync.WaitGroup) {
-	wg.Add(1)
 	defer wg.Done()
 
 	if viper.GetBool("free_tier") {
@@ -585,7 +582,6 @@ func fetchLogpushAnalyticsForAccount(account cfaccounts.Account, wg *sync.WaitGr
 }
 
 func fetchR2StorageForAccount(account cfaccounts.Account, wg *sync.WaitGroup) {
-	wg.Add(1)
 	defer wg.Done()
 
 	r, err := fetchR2Account(account.ID)
@@ -607,7 +603,6 @@ func fetchR2StorageForAccount(account cfaccounts.Account, wg *sync.WaitGroup) {
 }
 
 func fetchLogpushAnalyticsForZone(zones []cfzones.Zone, wg *sync.WaitGroup) {
-	wg.Add(1)
 	defer wg.Done()
 
 	if viper.GetBool("free_tier") {
@@ -636,7 +631,6 @@ func fetchLogpushAnalyticsForZone(zones []cfzones.Zone, wg *sync.WaitGroup) {
 }
 
 func fetchZoneColocationAnalytics(zones []cfzones.Zone, wg *sync.WaitGroup) {
-	wg.Add(1)
 	defer wg.Done()
 
 	// Colocation metrics are not available in non-enterprise zones
@@ -666,7 +660,6 @@ func fetchZoneColocationAnalytics(zones []cfzones.Zone, wg *sync.WaitGroup) {
 }
 
 func fetchZoneAnalytics(zones []cfzones.Zone, wg *sync.WaitGroup) {
-	wg.Add(1)
 	defer wg.Done()
 
 	// None of the below referenced metrics are available in the free tier
@@ -818,7 +811,6 @@ func addHTTPAdaptiveGroups(z *zoneResp, name string, account string) {
 }
 
 func fetchLoadBalancerAnalytics(zones []cfzones.Zone, wg *sync.WaitGroup) {
-	wg.Add(1)
 	defer wg.Done()
 
 	// None of the below referenced metrics are available in the free tier
@@ -872,7 +864,6 @@ func addLoadBalancingRequestsAdaptive(z *lbResp, name string, account string) {
 }
 
 func fetchZeroTrustAnalyticsForAccount(account cfaccounts.Account, wg *sync.WaitGroup) {
-	wg.Add(1)
 	defer wg.Done()
 
 	addCloudflareTunnelStatus(account)


### PR DESCRIPTION
This PR fixes a race condition where `wg.Add()` is called within the callee instead of the caller.

Incrementing the shared context should be done outside the callee to avoid this race, so I simply moved the calls to `wg.Add()`  right before the goroutines.
