### PR TITLE
Add account monthly data transfer usage metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dashboard.
 Required authentication scopes:
 
 - `Zone/Analytics:Read` is required for zone-level metrics
-- `Account/Account Analytics:Read` is required for Worker metrics
+- `Account/Account Analytics:Read` is required for Worker metrics and account usage metrics
 - `Account/Account Settings:Read` is required for Worker metrics (for listing accessible accounts, scraping all available
   Workers included in authentication scope)
 - `Zone/Firewall Services:Read` is required to fetch zone rule name for `cloudflare_zone_firewall_events_count` metric
@@ -79,6 +79,8 @@ The exporter can be configured using env variables or command flags.
 | `METRICS_DENYLIST` | (Optional) cloudflare-exporter metrics to not export, comma delimited list of cloudflare-exporter metrics. If not set, all metrics are exported |
 | `ENABLE_PPROF` | (Optional) enable pprof profiling endpoints at `/debug/pprof/`. Accepts `true` or `false`, default `false`. **Warning**: Only enable in development/debugging environments |
 | `ENABLE_EDGE_ERRORS_BY_PATH` | (Optional) enable edge errors by path metric. Accepts `true` or `false`, default `false`. See [Edge Errors by Path Metric](#edge-errors-by-path-metric-opt-in) |
+| `ENABLE_ACCOUNT_USAGE_METRICS` | (Optional) enable account-level current calendar month HTTP data transfer metrics. Accepts `true` or `false`, default `false`. See [Account HTTP Data Transfer Usage Metrics](#account-http-data-transfer-usage-metrics-opt-in) |
+| `ACCOUNT_USAGE_REQUEST_SOURCE` | (Optional) Cloudflare `requestSource` value for account usage metrics, default `eyeball`. |
 | `ZONE_<NAME>` |  `DEPRECATED since 0.0.5` (optional) Zone ID. Add zones you want to scrape by adding env vars in this format. You can find the zone ids in Cloudflare dashboards. |
 | `LOG_LEVEL` | Set loglevel. Options are error, warn, info, debug. default `error` |
 
@@ -100,6 +102,8 @@ Corresponding flags:
   -metrics_denylist="": cloudflare-exporter metrics to not export, comma delimited list
   -enable_pprof=false: enable pprof profiling endpoints at /debug/pprof/
   -enable_edge_errors_by_path=false: enable edge errors by path metric (high cardinality, opt-in)
+  -enable_account_usage_metrics=false: enable account-level current calendar month HTTP data transfer metrics
+  -account_usage_request_source="eyeball": Cloudflare requestSource value for account usage metrics
   -log_level="error": log level(error,warn,info,debug)
 ```
 
@@ -134,6 +138,10 @@ Note: `ZONE_<name>` configuration is not supported as flag.
 # HELP cloudflare_zone_requests_browser_map_page_views_count Number of successful requests for HTML pages per zone
 # HELP cloudflare_zone_requests_total Number of requests for zone
 # HELP cloudflare_zone_edge_errors_by_path Number of edge errors (4xx and 5xx) by request path
+# HELP cloudflare_account_http_data_transfer_month_to_date_bytes Account-level HTTP data transfer for the current calendar month to date in bytes
+# HELP cloudflare_account_http_data_transfer_projected_month_bytes Projected account-level HTTP data transfer for the current calendar month in bytes
+# HELP cloudflare_account_http_data_transfer_month_elapsed_seconds Elapsed seconds in the current calendar month used for account-level HTTP data transfer projection
+# HELP cloudflare_account_http_data_transfer_month_total_seconds Total seconds in the current calendar month used for account-level HTTP data transfer projection
 # HELP cloudflare_zone_threats_country Threats per zone per country
 # HELP cloudflare_zone_threats_total Threats per zone
 # HELP cloudflare_zone_uniques_total Uniques per zone
@@ -153,6 +161,37 @@ The `cloudflare_zone_edge_errors_by_path` metric tracks edge errors (4xx/5xx) by
 **Disabled by default** due to high cardinality. Enable with `ENABLE_EDGE_ERRORS_BY_PATH=true`.
 
 Paths are normalized to reduce cardinality (e.g., `/users/123` → `/users/:id`, UUIDs → `:uuid`).
+
+### Account HTTP Data Transfer Usage Metrics (Opt-in)
+
+The account-level HTTP data transfer usage metrics expose current UTC calendar month usage and projected month usage.
+
+**Disabled by default** to avoid extra GraphQL API calls. Enable with:
+
+```bash
+ENABLE_ACCOUNT_USAGE_METRICS=true
+ACCOUNT_USAGE_REQUEST_SOURCE=eyeball
+```
+
+The exporter queries Cloudflare GraphQL Analytics API for the current UTC calendar month range:
+
+```text
+month_start -> now
+```
+
+Projected month usage is calculated as:
+
+```text
+projected_month = month_to_date / elapsed_month_seconds * total_month_seconds
+```
+
+This can be used for monthly quota, budget, or committed usage alerts.
+
+Example alert:
+
+```promql
+cloudflare_account_http_data_transfer_projected_month_bytes > 100 * 1024 * 1024 * 1024 * 1024
+```
 
 ## Helm chart repository
 

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -109,7 +109,7 @@ type cloudflareResponseASN struct {
 type zoneRespASN struct {
 	ZoneTag string `json:"zoneTag"`
 
-	HttpRequestsASNGroups []struct {
+	HTTPRequestsASNGroups []struct {
 		Count      uint64 `json:"count"`
 		Dimensions struct {
 			Datetime             string `json:"datetime"`

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"strings"
+	"time"
 
 	cf "github.com/cloudflare/cloudflare-go/v4"
 	cfaccounts "github.com/cloudflare/cloudflare-go/v4/accounts"
@@ -30,6 +31,20 @@ type cloudflareResponseAccts struct {
 	Viewer struct {
 		Accounts []accountResp `json:"accounts"`
 	} `json:"viewer"`
+}
+
+type cloudflareResponseAccountHTTPDataTransfer struct {
+	Viewer struct {
+		Accounts []accountHTTPDataTransferResp `json:"accounts"`
+	} `json:"viewer"`
+}
+
+type accountHTTPDataTransferResp struct {
+	HTTPRequestsAdaptiveGroups []struct {
+		Sum struct {
+			EdgeResponseBytes uint64 `json:"edgeResponseBytes"`
+		} `json:"sum"`
+	} `json:"httpRequestsAdaptiveGroups"`
 }
 
 type cloudflareResponseColo struct {
@@ -110,7 +125,6 @@ type zoneRespASN struct {
 		} `json:"avg"`
 	} `json:"httpRequestsAdaptiveGroups"`
 }
-
 
 type cloudflareResponseEdgeErrorsByPath struct {
 	Viewer struct {
@@ -767,6 +781,48 @@ func fetchWorkerTotals(accountID string) (*cloudflareResponseAccts, error) {
 	var resp cloudflareResponseAccts
 	if err := gql.Client.Run(ctx, request, &resp); err != nil {
 		log.Errorf("error fetching worker totals, err:%v", err)
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func fetchAccountHTTPDataTransfer(accountID string, from time.Time, to time.Time, requestSource string) (*cloudflareResponseAccountHTTPDataTransfer, error) {
+	request := graphql.NewRequest(`
+query ($accountID: String!, $mintime: Time!, $maxtime: Time!, $requestSource: String!) {
+	viewer {
+		accounts(filter: {accountTag: $accountID}) {
+			httpRequestsAdaptiveGroups(
+				limit: 1
+				filter: {
+					datetime_geq: $mintime
+					datetime_lt: $maxtime
+					requestSource_in: [$requestSource]
+				}
+			) {
+				sum {
+					edgeResponseBytes
+				}
+			}
+		}
+	}
+}
+`)
+
+	request.Var("accountID", accountID)
+	request.Var("mintime", from)
+	request.Var("maxtime", to)
+	request.Var("requestSource", requestSource)
+
+	gql.Mu.RLock()
+	defer gql.Mu.RUnlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cftimeout)
+	defer cancel()
+
+	var resp cloudflareResponseAccountHTTPDataTransfer
+	if err := gql.Client.Run(ctx, request, &resp); err != nil {
+		log.Errorf("failed to fetch account HTTP data transfer, err:%v", err)
 		return nil, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -132,6 +132,9 @@ func fetchMetrics() {
 
 		wg.Add(1)
 		go fetchZeroTrustAnalyticsForAccount(a, &wg)
+
+		wg.Add(1)
+		go fetchAccountHTTPDataTransferAnalytics(a, &wg)
 	}
 
 	zones := fetchZones(accounts)
@@ -159,8 +162,8 @@ func fetchMetrics() {
 
 		wg.Add(1)
 		go fetchZoneASNAnalytics(filteredZones, &wg)
-    
-    wg.Add(1)
+
+		wg.Add(1)
 		go fetchEdgeErrorsByPathAnalytics(filteredZones, &wg)
 	} else if zoneCount > cfgraphqlreqlimit {
 		for s := 0; s < zoneCount; s += cfgraphqlreqlimit {
@@ -182,8 +185,8 @@ func fetchMetrics() {
 
 			wg.Add(1)
 			go fetchZoneASNAnalytics(filteredZones[s:e], &wg)
-      
-      wg.Add(1)
+
+			wg.Add(1)
 			go fetchEdgeErrorsByPathAnalytics(filteredZones[s:e], &wg)
 		}
 	}
@@ -316,6 +319,14 @@ func main() {
 	flags.Bool("enable_edge_errors_by_path", false, "enable edge errors by path metric (high cardinality)")
 	viper.BindEnv("enable_edge_errors_by_path")
 	viper.SetDefault("enable_edge_errors_by_path", false)
+
+	flags.Bool("enable_account_usage_metrics", false, "enable account-level current calendar month HTTP data transfer metrics")
+	viper.BindEnv("enable_account_usage_metrics")
+	viper.SetDefault("enable_account_usage_metrics", false)
+
+	flags.String("account_usage_request_source", "eyeball", "Cloudflare requestSource value for account usage metrics")
+	viper.BindEnv("account_usage_request_source")
+	viper.SetDefault("account_usage_request_source", "eyeball")
 
 	viper.BindPFlags(flags)
 

--- a/prometheus.go
+++ b/prometheus.go
@@ -1239,11 +1239,11 @@ func fetchZoneASNAnalytics(zones []cfzones.Zone, wg *sync.WaitGroup) {
 }
 
 func addASNGroups(z *zoneRespASN, name string, account string) {
-	if len(z.HttpRequestsASNGroups) == 0 {
+	if len(z.HTTPRequestsASNGroups) == 0 {
 		return
 	}
 
-	for _, g := range z.HttpRequestsASNGroups {
+	for _, g := range z.HTTPRequestsASNGroups {
 		asn := g.Dimensions.ClientASN
 		asnDesc := g.Dimensions.ClientASNDescription
 		if asnDesc == "" {

--- a/prometheus.go
+++ b/prometheus.go
@@ -66,6 +66,10 @@ const (
 	zoneRequestASNMetricName                        MetricName = "cloudflare_zone_requests_asn"
 	zoneBandwidthASNMetricName                      MetricName = "cloudflare_zone_bandwidth_asn"
 	zoneEdgeErrorsByPathMetricName                  MetricName = "cloudflare_zone_edge_errors_by_path"
+	accountHTTPDataTransferMonthToDateMetricName    MetricName = "cloudflare_account_http_data_transfer_month_to_date_bytes"
+	accountHTTPDataTransferProjectedMonthMetricName MetricName = "cloudflare_account_http_data_transfer_projected_month_bytes"
+	accountHTTPDataTransferMonthElapsedMetricName   MetricName = "cloudflare_account_http_data_transfer_month_elapsed_seconds"
+	accountHTTPDataTransferMonthTotalMetricName     MetricName = "cloudflare_account_http_data_transfer_month_total_seconds"
 )
 
 type MetricsSet map[MetricName]struct{}
@@ -347,11 +351,31 @@ var (
 		Name: zoneBandwidthASNMetricName.String(),
 		Help: "Bandwidth per ASN (Autonomous System Number) in bytes",
 	}, []string{"zone", "account", "asn", "asn_description"})
-  
+
 	zoneEdgeErrorsByPath = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: zoneEdgeErrorsByPathMetricName.String(),
 		Help: "Number of edge errors (4xx and 5xx) by request path",
 	}, []string{"zone", "account", "status", "host", "path"})
+
+	accountHTTPDataTransferMonthToDate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: accountHTTPDataTransferMonthToDateMetricName.String(),
+		Help: "Account-level HTTP data transfer for the current calendar month to date in bytes",
+	}, []string{"account"})
+
+	accountHTTPDataTransferProjectedMonth = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: accountHTTPDataTransferProjectedMonthMetricName.String(),
+		Help: "Projected account-level HTTP data transfer for the current calendar month in bytes",
+	}, []string{"account"})
+
+	accountHTTPDataTransferMonthElapsed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: accountHTTPDataTransferMonthElapsedMetricName.String(),
+		Help: "Elapsed seconds in the current calendar month used for account-level HTTP data transfer projection",
+	}, []string{"account"})
+
+	accountHTTPDataTransferMonthTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: accountHTTPDataTransferMonthTotalMetricName.String(),
+		Help: "Total seconds in the current calendar month used for account-level HTTP data transfer projection",
+	}, []string{"account"})
 )
 
 func buildAllMetricsSet() MetricsSet {
@@ -401,6 +425,10 @@ func buildAllMetricsSet() MetricsSet {
 	allMetricsSet.Add(zoneRequestASNMetricName)
 	allMetricsSet.Add(zoneBandwidthASNMetricName)
 	allMetricsSet.Add(zoneEdgeErrorsByPathMetricName)
+	allMetricsSet.Add(accountHTTPDataTransferMonthToDateMetricName)
+	allMetricsSet.Add(accountHTTPDataTransferProjectedMonthMetricName)
+	allMetricsSet.Add(accountHTTPDataTransferMonthElapsedMetricName)
+	allMetricsSet.Add(accountHTTPDataTransferMonthTotalMetricName)
 	return allMetricsSet
 }
 
@@ -552,9 +580,21 @@ func mustRegisterMetrics(deniedMetrics MetricsSet) {
 	}
 	if !deniedMetrics.Has(zoneBandwidthASNMetricName) {
 		prometheus.MustRegister(zoneBandwidthASN)
-  }
+	}
 	if !deniedMetrics.Has(zoneEdgeErrorsByPathMetricName) {
 		prometheus.MustRegister(zoneEdgeErrorsByPath)
+	}
+	if !deniedMetrics.Has(accountHTTPDataTransferMonthToDateMetricName) {
+		prometheus.MustRegister(accountHTTPDataTransferMonthToDate)
+	}
+	if !deniedMetrics.Has(accountHTTPDataTransferProjectedMonthMetricName) {
+		prometheus.MustRegister(accountHTTPDataTransferProjectedMonth)
+	}
+	if !deniedMetrics.Has(accountHTTPDataTransferMonthElapsedMetricName) {
+		prometheus.MustRegister(accountHTTPDataTransferMonthElapsed)
+	}
+	if !deniedMetrics.Has(accountHTTPDataTransferMonthTotalMetricName) {
+		prometheus.MustRegister(accountHTTPDataTransferMonthTotal)
 	}
 }
 
@@ -1049,6 +1089,60 @@ func fetchZeroTrustAnalyticsForAccount(account cfaccounts.Account, wg *sync.Wait
 	defer wg.Done()
 
 	addCloudflareTunnelStatus(account)
+}
+
+func fetchAccountHTTPDataTransferAnalytics(account cfaccounts.Account, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	if !viper.GetBool("enable_account_usage_metrics") {
+		return
+	}
+
+	now, monthStart, nextMonthStart := GetMonthRange()
+	requestSource := viper.GetString("account_usage_request_source")
+
+	r, err := fetchAccountHTTPDataTransfer(account.ID, monthStart, now, requestSource)
+	if err != nil {
+		log.Error("failed to fetch account HTTP data transfer analytics for account ", account.ID, ": ", err)
+		return
+	}
+
+	elapsedSeconds := now.Sub(monthStart).Seconds()
+	totalSeconds := nextMonthStart.Sub(monthStart).Seconds()
+
+	addAccountHTTPDataTransfer(r, account, elapsedSeconds, totalSeconds)
+}
+
+func addAccountHTTPDataTransfer(r *cloudflareResponseAccountHTTPDataTransfer, account cfaccounts.Account, elapsedSeconds float64, totalSeconds float64) {
+	accountName := account.Name
+	if accountName == "" {
+		accountName = account.ID
+	} else {
+		accountName = strings.ToLower(strings.ReplaceAll(accountName, " ", "-"))
+	}
+
+	labels := prometheus.Labels{"account": accountName}
+
+	accountHTTPDataTransferMonthToDate.DeletePartialMatch(labels)
+	accountHTTPDataTransferProjectedMonth.DeletePartialMatch(labels)
+	accountHTTPDataTransferMonthElapsed.DeletePartialMatch(labels)
+	accountHTTPDataTransferMonthTotal.DeletePartialMatch(labels)
+
+	var monthToDateBytes uint64
+
+	if len(r.Viewer.Accounts) > 0 && len(r.Viewer.Accounts[0].HTTPRequestsAdaptiveGroups) > 0 {
+		monthToDateBytes = r.Viewer.Accounts[0].HTTPRequestsAdaptiveGroups[0].Sum.EdgeResponseBytes
+	}
+
+	projectedMonthBytes := 0.0
+	if elapsedSeconds > 0 {
+		projectedMonthBytes = float64(monthToDateBytes) / elapsedSeconds * totalSeconds
+	}
+
+	accountHTTPDataTransferMonthToDate.With(labels).Set(float64(monthToDateBytes))
+	accountHTTPDataTransferProjectedMonth.With(labels).Set(projectedMonthBytes)
+	accountHTTPDataTransferMonthElapsed.With(labels).Set(elapsedSeconds)
+	accountHTTPDataTransferMonthTotal.With(labels).Set(totalSeconds)
 }
 
 func addCloudflareTunnelStatus(account cfaccounts.Account) {

--- a/utils.go
+++ b/utils.go
@@ -18,6 +18,16 @@ func GetTimeRange() (now time.Time, now1mAgo time.Time) {
 	return now, now1mAgo
 }
 
+func GetMonthRange() (now time.Time, monthStart time.Time, nextMonthStart time.Time) {
+	now = time.Now().Add(-time.Duration(viper.GetInt("scrape_delay")) * time.Second).UTC()
+	now = now.Truncate(time.Minute)
+
+	monthStart = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	nextMonthStart = monthStart.AddDate(0, 1, 0)
+
+	return now, monthStart, nextMonthStart
+}
+
 func jsonStringToMap(fields string) (map[string]interface{}, error) {
 	var extraFields map[string]interface{}
 	err := json.Unmarshal([]byte(fields), &extraFields)


### PR DESCRIPTION
## Pull Request Template

### Description

Adds optional account-level current UTC calendar month HTTP data transfer usage metrics.

The feature is disabled by default and can be enabled with:

```bash
ENABLE_ACCOUNT_USAGE_METRICS=true
ACCOUNT_USAGE_REQUEST_SOURCE=eyeball
```
New metrics:
```
cloudflare_account_http_data_transfer_month_to_date_bytes
cloudflare_account_http_data_transfer_projected_month_bytes
cloudflare_account_http_data_transfer_month_elapsed_seconds
cloudflare_account_http_data_transfer_month_total_seconds
```

The projected month value is calculated as:

projected_month = month_to_date / elapsed_month_seconds * total_month_seconds

This is useful for monthly quota, budget, or committed usage alerting without reconstructing current calendar month usage from counters.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring
- [ ] Other (please describe):

### Testing
- [ ] I have run `make pr-tests` and all tests pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation