### PR TITLE
feat: resolve rule names for rate limiting firewall events

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -463,33 +463,17 @@ func fetchFirewallRules(zoneID string) map[string]string {
 	firewallRulesMap := make(map[string]string)
 
 	for _, rulesetDesc := range listOfRulesets {
-		if rulesetDesc.Phase == cfrulesets.PhaseHTTPRequestFirewallManaged {
+		switch rulesetDesc.Phase {
+		case cfrulesets.PhaseHTTPRequestFirewallManaged,
+			cfrulesets.PhaseHTTPRequestFirewallCustom,
+			cfrulesets.PhaseHTTPRatelimit:
 			ctx, cancel := context.WithTimeout(context.Background(), cftimeout)
-			ruleset, err := cfclient.Rulesets.Get(ctx, rulesetDesc.ID, cfrulesets.RulesetGetParams{
-				ZoneID: cf.F(zoneID),
-			})
+			ruleset, err := cfclient.Rulesets.Get(ctx, rulesetDesc.ID, cfrulesets.RulesetGetParams{ZoneID: cf.F(zoneID)})
+			cancel()
 			if err != nil {
-				log.Errorf("error fetching ruleset for managed firewall rules, ZoneID:%s, RulesetID:%s, Err:%v", zoneID, rulesetDesc.ID, err)
-				cancel()
+				log.Errorf("error fetching ruleset, ZoneID:%s, RulesetID:%s, Phase:%s, Err:%v", zoneID, rulesetDesc.ID, rulesetDesc.Phase, err)
 				continue
 			}
-			cancel()
-			for _, rule := range ruleset.Rules {
-				firewallRulesMap[rule.ID] = rule.Description
-			}
-		}
-
-		if rulesetDesc.Phase == cfrulesets.PhaseHTTPRequestFirewallCustom {
-			ctx, cancel := context.WithTimeout(context.Background(), cftimeout)
-			ruleset, err := cfclient.Rulesets.Get(ctx, rulesetDesc.ID, cfrulesets.RulesetGetParams{
-				ZoneID: cf.F(zoneID),
-			})
-			if err != nil {
-				log.Errorf("error fetching ruleset for custom firewall rules, ZoneID:%s, RulesetID:%s, Err:%v", zoneID, rulesetDesc.ID, err)
-				cancel()
-				continue
-			}
-			cancel()
 			for _, rule := range ruleset.Rules {
 				firewallRulesMap[rule.ID] = rule.Description
 			}


### PR DESCRIPTION
### Description

Rate limiting events are already exported in `cloudflare_zone_firewall_events_count` with `source="ratelimit"`, but `fetchFirewallRules` only resolves rule names for the `http_request_firewall_managed` and `http_request_firewall_custom` phases.  This change adds the missing rule name.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

### Testing
- [x] I have run `make pr-tests` and all tests pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

### Before Submitting
Please ensure you have completed the following before submitting your PR:

```bash
# Run comprehensive tests
make pr-tests
```

If the above command fails, please fix the issues before submitting your PR.

### Additional Notes
Add any other context about the pull request here.
